### PR TITLE
Add Windows and macOS platforms

### DIFF
--- a/components/GlobalPlatformControl.tsx
+++ b/components/GlobalPlatformControl.tsx
@@ -30,7 +30,9 @@ export default function GlobalPlatformControl({ query }: { query: { [key: string
       <ToggleLink query={query} paramName="ios" title="iOS" />
       <ToggleLink query={query} paramName="android" title="Android" />
       <ToggleLink query={query} paramName="web" title="Web" />
-      <ToggleLink query={query} paramName="expo" title="Managed Expo" />
+      <ToggleLink query={query} paramName="windows" title="Windows" />
+      <ToggleLink query={query} paramName="macos" title="macOS" />
+      <ToggleLink query={query} paramName="expo" title="Expo client" />
     </View>
   );
 }

--- a/components/LibraryListItemColumnTwo.tsx
+++ b/components/LibraryListItemColumnTwo.tsx
@@ -37,9 +37,9 @@ export default function LibraryListItemColumnTwo(props) {
           props.library.ios ? '✅ iOS' : '⛔ iOS',
           props.library.android ? '✅ Android' : '⛔ Android',
           props.library.web ? '✅ Web' : '⛔ Web',
-          props.library.expo && typeof props.library.expo !== 'string'
-            ? '✅ Managed Expo'
-            : '⛔ Managed Expo',
+          props.library.windows ? '✅ Windows' : '⛔ Windows',
+          props.library.macos ? '✅ macOS' : '⛔ macOS',
+          props.library.expo ? '✅ Expo client' : '⛔ Expo client',
         ].map(each => {
           return `${each}   `;
         })}

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -45,8 +45,10 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
     support: {
       ios: req.query.ios,
       android: req.query.android,
-      expo: req.query.expo,
       web: req.query.web,
+      windows: req.query.windows,
+      macos: req.query.macos,
+      expo: req.query.expo,
     },
   });
 

--- a/react-native-libraries.schema.json
+++ b/react-native-libraries.schema.json
@@ -8,18 +8,14 @@
     "$id": "#/items",
     "type": "object",
     "title": "The Items Schema",
-    "required": [
-      "githubUrl"
-    ],
+    "required": ["githubUrl"],
     "properties": {
       "githubUrl": {
         "$id": "#/items/properties/githubUrl",
         "type": "string",
         "title": "The Githuburl Schema",
         "default": "",
-        "examples": [
-          "https://github.com/joshswan/react-native-autolink"
-        ],
+        "examples": ["https://github.com/joshswan/react-native-autolink"],
         "pattern": "^(.*)$"
       },
       "ios": {
@@ -27,27 +23,35 @@
         "type": "boolean",
         "title": "The Ios Schema",
         "default": false,
-        "examples": [
-          true
-        ]
+        "examples": [true]
       },
       "android": {
         "$id": "#/items/properties/android",
         "type": "boolean",
         "title": "The Android Schema",
         "default": false,
-        "examples": [
-          true
-        ]
+        "examples": [true]
+      },
+      "windows": {
+        "$id": "#/items/properties/windows",
+        "type": "boolean",
+        "title": "The Windows Schema",
+        "default": false,
+        "examples": [true]
+      },
+      "macos": {
+        "$id": "#/items/properties/macos",
+        "type": "boolean",
+        "title": "The macOS Schema",
+        "default": false,
+        "examples": [true]
       },
       "expo": {
         "$id": "#/items/properties/expo",
         "type": "boolean",
         "title": "The Expo Schema",
         "default": false,
-        "examples": [
-          true
-        ]
+        "examples": [true]
       },
       "examples": {
         "$id": "#/items/properties/examples",
@@ -59,9 +63,7 @@
           "type": "string",
           "title": "The Items Schema",
           "default": "",
-          "examples": [
-            "https://snack.expo.io/SkRP2Ehrb"
-          ],
+          "examples": ["https://snack.expo.io/SkRP2Ehrb"],
           "pattern": "^(.*)$"
         }
       },
@@ -70,9 +72,7 @@
         "type": "string",
         "title": "The Npmpkg Schema",
         "default": "",
-        "examples": [
-          "@expo/ex-navigation"
-        ],
+        "examples": ["@expo/ex-navigation"],
         "pattern": "^(.*)$"
       },
       "unmaintained": {
@@ -80,9 +80,7 @@
         "type": "boolean",
         "title": "The Unmaintained Schema",
         "default": false,
-        "examples": [
-          true
-        ]
+        "examples": [true]
       }
     }
   }

--- a/util/search.js
+++ b/util/search.js
@@ -20,6 +20,14 @@ export const handleFilterLibraries = ({ libraries, queryTopic, querySearch, supp
       return false;
     }
 
+    if (support.windows && !library.windows) {
+      return false;
+    }
+
+    if (support.macos && !library.macos) {
+      return false;
+    }
+
     if (support.expo && !library.expo) {
       return false;
     }


### PR DESCRIPTION
# Summary

Microsoft is investing a lot in React Native for Windows and macOS. As their adoption grows outside of Microsoft it will be useful to see which libraries are supported on those platforms!

This PR adds filters but does not mark any libraries as compatible with either yet. Waiting on @stmoy to come up with a list of them before we merge this.

## Test Plan

Try the URL that is linked to below.