### PR TITLE
Add react-native-media-clipboard

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3268,6 +3268,14 @@
     "npmPkg": "react-native-zoomable-view"
   },
   {
+    "githubUrl": "https://github.com/Jarred-Sumner/react-native-media-clipboard",
+    "ios": true,
+    "android": false,
+    "web": false,
+    "expo": false,
+    "npmPkg": "react-native-media-clipboard"
+  },
+  {
     "githubUrl": "https://github.com/tunoltd/emoji-mart-native",
     "ios": true,
     "android": true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

[`react-native-media-clipboard`](https://github.com/Jarred-Sumner/react-native-media-clipboard) lets you get images, strings, and URLs from the clipboard. It exposes a React Context that updates whenever the clipboard changes. Images are saved to disk in the temporary directory in a background thread.

There's an [example repo](https://github.com/Jarred-Sumner/react-native-media-clipboard-example), here's a screenshot:
<img src="https://user-images.githubusercontent.com/709451/74532509-395b0d80-4ee4-11ea-8778-e455671c3aa3.png" height=300 />


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow) (there are type definitions)
- [X] I added a sample use of the API in the example project (`example/App.js`)
