### PR TITLE
Update React Native Elements URL

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -682,7 +682,7 @@
   },
   {
     "githubUrl":
-      "https://github.com/react-native-training/react-native-elements",
+      "https://github.com/react-native-elements/react-native-elements",
     "ios": true,
     "android": true,
     "expo": true


### PR DESCRIPTION
# Summary

The repo has been moved under the `react-native-elements` orga
