### PR TITLE
Mobile design fixes

### DIFF
--- a/common/styleguide.tsx
+++ b/common/styleguide.tsx
@@ -1,10 +1,16 @@
 import React, { ReactNode, RefObject } from 'react';
 import { StyleSheet, TextStyle } from 'react-native';
-import { useHover } from 'react-native-web-hooks';
+import { useHover, useDimensions } from 'react-native-web-hooks';
 import * as HtmlElements from '@expo/html-elements';
 
 export const layout = {
   maxWidth: 1200,
+  isSmallScreen: () => {
+    const {
+      window: { width },
+    } = useDimensions();
+    return width < 800;
+  },
 };
 
 export const colors = {

--- a/components/CompatibilityTags.tsx
+++ b/components/CompatibilityTags.tsx
@@ -36,6 +36,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     flexWrap: 'wrap',
+    marginBottom: -4,
   },
   tag: {
     flexDirection: 'row',
@@ -47,6 +48,7 @@ const styles = StyleSheet.create({
     borderRadius: 2,
     paddingHorizontal: 6,
     paddingVertical: 4,
+    marginBottom: 4,
   },
   text: {
     marginLeft: 4,

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,7 +11,7 @@ export default function Header() {
       <View style={styles.headerContents}>
         <View style={styles.displayHorizontal}>
           <Logo fill={colors.primary} width={29} height={26} />
-          <H5>
+          <H5 style={layout.isSmallScreen() && styles.smallTitle}>
             <A href="/" style={styles.headerContentsTitle}>
               React Native Directory
             </A>
@@ -20,7 +20,8 @@ export default function Header() {
         <Button href="https://github.com/react-native-community/directory#how-do-i-add-a-library">
           <View style={styles.displayHorizontal}>
             <>
-              <Plus width={14} height={14} /> <P style={{ marginLeft: 6 }}>Add a library</P>
+              <Plus width={14} height={14} />
+              {!layout.isSmallScreen() && <P style={{ marginLeft: 6 }}>Add a library</P>}
             </>
           </View>
         </Button>
@@ -52,5 +53,8 @@ let styles = StyleSheet.create({
   displayHorizontal: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  smallTitle: {
+    fontSize: 18,
   },
 });

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useDimensions } from 'react-native-web-hooks';
 import { Library as LibraryType } from '../../types';
 import { isEmptyOrNull } from '../../util/strings';
-import { colors, A, Label, Caption } from '../../common/styleguide';
+import { colors, layout, A, Label, Caption } from '../../common/styleguide';
 import { Badge } from '../Icons';
 import { CompatibilityTags } from '../CompatibilityTags';
 import { MetaData } from './MetaData';
@@ -14,13 +13,9 @@ type Props = {
 
 export default function Library(props: Props) {
   const { library } = props;
-  const {
-    window: { width },
-  } = useDimensions();
-  const isSmallScreen = width < 800;
 
   return (
-    <View style={[styles.container, isSmallScreen && styles.containerColumn]}>
+    <View style={[styles.container, layout.isSmallScreen() && styles.containerColumn]}>
       <View style={styles.columnOne}>
         <View style={styles.displayHorizontal}>
           <A href={library.github.urls.repo} style={styles.name} hoverStyle={styles.nameHovered}>
@@ -52,7 +47,7 @@ export default function Library(props: Props) {
           </View>
         ) : null}
       </View>
-      <View style={[styles.columnTwo, isSmallScreen && styles.columnTwoSmall]}>
+      <View style={[styles.columnTwo, layout.isSmallScreen() && styles.columnTwoSmall]}>
         <MetaData library={library} />
       </View>
     </View>

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -37,8 +37,13 @@ export default function Search(props: Props) {
               <SearchIcon fill={colors.white} />
             </View>
           </View>
-          <View style={[styles.displayHorizontal, styles.resultsContainer]}>
-            <P style={{ color: colors.white }}>
+          <View
+            style={[
+              styles.displayHorizontal,
+              styles.resultsContainer,
+              layout.isSmallScreen() && styles.smallResultsContainer,
+            ]}>
+            <P style={styles.totalText}>
               {total} {total === 1 ? 'library' : 'libraries'}
             </P>
             <View style={styles.displayHorizontal}>
@@ -91,5 +96,13 @@ const styles = StyleSheet.create({
   resultsContainer: {
     marginTop: 8,
     justifyContent: 'space-between',
+  },
+  smallResultsContainer: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  },
+  totalText: {
+    color: colors.white,
+    marginBottom: 8,
   },
 });


### PR DESCRIPTION
# Why

There were some issues with the mobile-readiness of the redesign:

- The "Add to Library" button gets chopped off and is too large.
- The "### libraries" and filter/sort buttons need to get stacked instead of displayed inline.
- The compatibility tags  need margin bottom so they can wrap correctly without touching each other.

This PR fixes those things!

# Screenshots

## Before
![reactnative directory_(iPhone 5_SE)](https://user-images.githubusercontent.com/6455018/77829787-a9230180-70fa-11ea-9c79-181ea39ec4a8.png)

## After
![localhost_3000_(iPhone 5_SE)](https://user-images.githubusercontent.com/6455018/77829788-a9bb9800-70fa-11ea-8c84-cd52f72a0b54.png)

