### PR TITLE
Fix expo flag for react-native-azure-auth

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -2394,7 +2394,7 @@
     "ios": true,
     "android": true,
     "web": false,
-    "expo": true
+    "expo": false
   },
   {
     "githubUrl": "https://github.com/doomsower/react-native-modal-popover",


### PR DESCRIPTION
# Why

Fix wrong expo flag for `react-native-azure-auth` library