### PR TITLE
Removed duplicate entry for react-native-text-input-mask

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3507,17 +3507,8 @@
     "web": false,
     "expo": false,
     "windows": false,
-    "unmaintained": false
-  },
-  {
-    "githubUrl": "https://github.com/react-native-community/react-native-text-input-mask",
-    "ios": true,
-    "android": true,
-    "web": false,
-    "expo": false,
-    "windows": false,
     "unmaintained": false,
-    "npmPkg": "@react-native-community/voice"
+    "npmPkg": "react-native-text-input-mask"
   },
   {
     "githubUrl": "https://github.com/react-native-community/toolbar-android",


### PR DESCRIPTION
# Why

Removed a duplicate entry for `react-native-text-input-mask` that listed the wrong npm package (`@react-native-community/voice`)

# Checklist

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
