### PR TITLE
Mark react-native-card-io as Unmaintained

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -793,7 +793,8 @@
   {
     "githubUrl": "https://github.com/kayla-tech/react-native-card-io",
     "ios": true,
-    "android": true
+    "android": true,
+    "unmaintained: true
   },
   {
     "githubUrl": "https://github.com/Kerumen/react-native-awesome-card-io",


### PR DESCRIPTION
# Why

This PR marks the react-naitve-card-io library as "unmaintained."

This particular library hasn't been updated in 4 years.  In addition, card.io just archived their iOS and Android SDKs, which this library is a wrapper for. 

# Checklist

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
