### PR TITLE
Mark react-native-smart-badge Library Unmaintained

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1383,7 +1383,8 @@
     "githubUrl": "https://github.com/react-native-component/react-native-smart-badge",
     "ios": true,
     "android": true,
-    "expo": true
+    "expo": true,
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/gcanti/tcomb-form-native",


### PR DESCRIPTION
# Why

This PR marks the react-native-smart-badge library as "unmaintained."

The library hasn't been updated since November 2016. It is not compatible with any of the recent version of RN because it relies on PropTypes from React-Native.  There are 3 open PRs from 2017 that would fix the issue, but none have been merged.

# Checklist
N/A