### PR TITLE
Added Parse SDK package

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3679,5 +3679,15 @@
     "windows": false,
     "unmaintained": false,
     "npmPkg": "react-native-voip-push-notification"
+  },
+  {
+    "githubUrl": "https://github.com/parse-community/Parse-SDK-JS",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false,
+    "windows": false,
+    "npmPkg": "parse",
+    "unmaintained": false
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3684,8 +3684,8 @@
     "githubUrl": "https://github.com/parse-community/Parse-SDK-JS",
     "ios": true,
     "android": true,
-    "web": false,
-    "expo": false,
+    "web": true,
+    "expo": true,
     "windows": false,
     "npmPkg": "parse",
     "unmaintained": false


### PR DESCRIPTION
# Why

Added Parse SDK for the [Parse Platform](https://parseplatform.org/)
- I _think_ it might work on Expo, and Web as the SDK was initially focused on vanilla JS (for web) but I haven't used it on those. Can confirm that it **works on iOS and Android**.

# Checklist

If you added a new library:

- [x] Added it to **react-native-libraries.json**
