### PR TITLE
add react-native-bootsplash package

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3691,5 +3691,15 @@
     "windows": false,
     "unmaintained": false,
     "npmPkg": "react-native-voip-push-notification"
-  }
+  },
+    {
+    "githubUrl": "https://github.com/zoontek/react-native-bootsplash",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false,
+    "windows": false,
+    "unmaintained": false,
+    "npmPkg": "react-native-bootsplash"
+  },
 ]


### PR DESCRIPTION
Added the [react-native-bootsplash](https://github.com/zoontek/react-native-bootsplash) library.  

# Why

This is a relatively new, extremely well-maintained splash screen library.  This library supports Storyboards instead of .xib splash screens, which is now required on iOS.

I am not sure if it works on expo and windows. My guess would be that it does not, but I cannot confirm.

# Checklist

If you added a new library:

- [x] Added it to **react-native-libraries.json**
