### PR TITLE
Add topics and make searching by topics simpler

### DIFF
--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -5,6 +5,7 @@ import { isEmptyOrNull } from '../../util/strings';
 import { colors, layout, A, Label, Caption } from '../../common/styleguide';
 import { Badge } from '../Icons';
 import { CompatibilityTags } from '../CompatibilityTags';
+import { Topics } from '../Topics';
 import { MetaData } from './MetaData';
 
 type Props = {
@@ -21,6 +22,7 @@ export default function Library(props: Props) {
           <A href={library.github.urls.repo} style={styles.name} hoverStyle={styles.nameHovered}>
             {library.github.name}
           </A>
+
           {library.goldstar && (
             <View style={[styles.displayHorizontal, styles.recommendedContainer]}>
               <Badge width={11} height={16} />
@@ -30,6 +32,9 @@ export default function Library(props: Props) {
         </View>
         <View style={styles.verticalMargin}>
           <CompatibilityTags library={library} />
+        </View>
+        <View style={styles.verticalMargin}>
+          <Topics library={library} />
         </View>
         {!isEmptyOrNull(library.github.description) && (
           <View style={styles.verticalMargin}>

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -30,7 +30,7 @@ export default function Search(props: Props) {
               onChangeText={debouncedCallback}
               placeholder="Search libraries..."
               style={styles.textInput}
-              defaultValue={query && query.search}
+              value={query && query.search ? query.search : ''}
               placeholderTextColor={colors.gray4}
             />
             <View style={styles.searchIcon}>

--- a/components/Topics.tsx
+++ b/components/Topics.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
-import Link from 'next/link';
 import Router, { useRouter } from 'next/router';
 import { useDebouncedCallback } from 'use-debounce';
 import { Library } from '../types';
@@ -21,16 +20,9 @@ export function Topics(props: Props) {
   return (
     <View style={styles.container}>
       {topics.map(topic => (
-        // <Link
-        //   key={topic}
-        //   href={urlWithQuery('/', {
-        //     ...router.query,
-        //     search: topic,
-        //   })}>
         <TouchableOpacity key={topic} style={styles.tag} onPress={() => debouncedCallback(topic)}>
           <Label style={styles.text}>{topic}</Label>
         </TouchableOpacity>
-        // </Link>
       ))}
     </View>
   );

--- a/components/Topics.tsx
+++ b/components/Topics.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import Link from 'next/link';
+import Router, { useRouter } from 'next/router';
+import { useDebouncedCallback } from 'use-debounce';
+import { Library } from '../types';
+import { colors, Label } from '../common/styleguide';
+import urlWithQuery from '../util/urlWithQuery';
+
+type Props = {
+  library: Library;
+};
+
+export function Topics(props: Props) {
+  const { library } = props;
+  const { topics } = library.github;
+  const router = useRouter();
+  const [debouncedCallback] = useDebouncedCallback(text => {
+    Router.replace(urlWithQuery('/', { ...router.query, search: text, offset: null }));
+  }, 150);
+  return (
+    <View style={styles.container}>
+      {topics.map(topic => (
+        // <Link
+        //   key={topic}
+        //   href={urlWithQuery('/', {
+        //     ...router.query,
+        //     search: topic,
+        //   })}>
+        <TouchableOpacity key={topic} style={styles.tag} onPress={() => debouncedCallback(topic)}>
+          <Label style={styles.text}>{topic}</Label>
+        </TouchableOpacity>
+        // </Link>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    marginBottom: -4,
+  },
+  tag: {
+    alignItems: 'center',
+    backgroundColor: colors.primaryDark,
+    marginRight: 8,
+    borderRadius: 2,
+    paddingHorizontal: 5,
+    paddingVertical: 5,
+    marginBottom: 4,
+    cursor: 'pointer',
+  },
+  text: {
+    color: colors.white,
+  },
+});


### PR DESCRIPTION
I have displayed the topics associated with each library and also made them clickable. This way, whenever a user clicks a topic, they can search by that specific topic.

I also created a small demo to see the feature in action.
![add-topics](https://user-images.githubusercontent.com/10681116/81478907-3bd0b900-91ee-11ea-9d9f-655daeb93b86.gif)

