### PR TITLE
Add react-context-theming library

### DIFF
--- a/assets/data.json
+++ b/assets/data.json
@@ -17,13 +17,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-branch",
         "fullName": "expo/expo",
@@ -37,9 +37,9 @@
       },
       "npmPkg": "expo-branch",
       "npm": {
-        "downloads": 2190,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2196,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -69,13 +69,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-ads-admob",
         "fullName": "expo/expo",
@@ -89,9 +89,9 @@
       },
       "npmPkg": "expo-ads-admob",
       "npm": {
-        "downloads": 41035,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 41930,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -121,13 +121,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-ads-facebook",
         "fullName": "expo/expo",
@@ -140,9 +140,9 @@
       },
       "npmPkg": "expo-ads-facebook",
       "npm": {
-        "downloads": 29606,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 30423,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -172,13 +172,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-analytics-amplitude",
         "fullName": "expo/expo",
@@ -191,9 +191,9 @@
       },
       "npmPkg": "expo-analytics-amplitude",
       "npm": {
-        "downloads": 42168,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 43481,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -223,13 +223,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-analytics-segment",
         "fullName": "expo/expo",
@@ -243,9 +243,9 @@
       },
       "npmPkg": "expo-analytics-segment",
       "npm": {
-        "downloads": 65487,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 67423,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -275,13 +275,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-app-auth",
         "fullName": "expo/expo",
@@ -301,9 +301,9 @@
       },
       "npmPkg": "expo-app-auth",
       "npm": {
-        "downloads": 52458,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 53553,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -333,13 +333,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-apple-authentication",
         "fullName": "expo/expo",
@@ -353,9 +353,9 @@
       },
       "npmPkg": "expo-apple-authentication",
       "npm": {
-        "downloads": 16826,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 17267,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -385,13 +385,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-application",
         "fullName": "expo/expo",
@@ -404,9 +404,9 @@
       },
       "npmPkg": "expo-application",
       "npm": {
-        "downloads": 3782,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3948,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -436,13 +436,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-asset",
         "fullName": "expo/expo",
@@ -455,9 +455,9 @@
       },
       "npmPkg": "expo-asset",
       "npm": {
-        "downloads": 429688,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 440204,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -487,13 +487,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-av",
         "fullName": "expo/expo",
@@ -507,9 +507,9 @@
       },
       "npmPkg": "expo-av",
       "npm": {
-        "downloads": 84701,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 87293,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -539,13 +539,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-background-fetch",
         "fullName": "expo/expo",
@@ -560,9 +560,9 @@
       },
       "npmPkg": "expo-background-fetch",
       "npm": {
-        "downloads": 36869,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 37724,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -592,13 +592,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-barcode-scanner",
         "fullName": "expo/expo",
@@ -612,9 +612,9 @@
       },
       "npmPkg": "expo-barcode-scanner",
       "npm": {
-        "downloads": 70782,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 72802,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -644,13 +644,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-battery",
         "fullName": "expo/expo",
@@ -663,9 +663,9 @@
       },
       "npmPkg": "expo-battery",
       "npm": {
-        "downloads": 1527,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1574,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -695,13 +695,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-blur",
         "fullName": "expo/expo",
@@ -714,9 +714,9 @@
       },
       "npmPkg": "expo-blur",
       "npm": {
-        "downloads": 49048,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 50398,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -746,13 +746,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-brightness",
         "fullName": "expo/expo",
@@ -766,9 +766,9 @@
       },
       "npmPkg": "expo-brightness",
       "npm": {
-        "downloads": 33861,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 34869,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -798,13 +798,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-calendar",
         "fullName": "expo/expo",
@@ -818,9 +818,9 @@
       },
       "npmPkg": "expo-calendar",
       "npm": {
-        "downloads": 30676,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 31530,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -850,13 +850,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-camera",
         "fullName": "expo/expo",
@@ -869,9 +869,9 @@
       },
       "npmPkg": "expo-camera",
       "npm": {
-        "downloads": 71482,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 73260,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -901,13 +901,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-cellular",
         "fullName": "expo/expo",
@@ -920,9 +920,9 @@
       },
       "npmPkg": "expo-cellular",
       "npm": {
-        "downloads": 1383,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1426,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -952,13 +952,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-constants",
         "fullName": "expo/expo",
@@ -971,9 +971,9 @@
       },
       "npmPkg": "expo-constants",
       "npm": {
-        "downloads": 465877,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 477145,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1003,13 +1003,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-contacts",
         "fullName": "expo/expo",
@@ -1022,9 +1022,9 @@
       },
       "npmPkg": "expo-contacts",
       "npm": {
-        "downloads": 50567,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 51746,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1054,13 +1054,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-crypto",
         "fullName": "expo/expo",
@@ -1078,9 +1078,9 @@
       },
       "npmPkg": "expo-crypto",
       "npm": {
-        "downloads": 38764,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 39952,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1110,13 +1110,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-device",
         "fullName": "expo/expo",
@@ -1129,9 +1129,9 @@
       },
       "npmPkg": "expo-device",
       "npm": {
-        "downloads": 13763,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14177,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1161,13 +1161,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-document-picker",
         "fullName": "expo/expo",
@@ -1181,9 +1181,9 @@
       },
       "npmPkg": "expo-document-picker",
       "npm": {
-        "downloads": 39994,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 41259,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1213,13 +1213,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-error-recovery",
         "fullName": "expo/expo",
@@ -1233,9 +1233,9 @@
       },
       "npmPkg": "expo-error-recovery",
       "npm": {
-        "downloads": 267851,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 272989,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1265,13 +1265,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-face-detector",
         "fullName": "expo/expo",
@@ -1286,9 +1286,9 @@
       },
       "npmPkg": "expo-face-detector",
       "npm": {
-        "downloads": 38242,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 39118,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1318,13 +1318,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-facebook",
         "fullName": "expo/expo",
@@ -1337,9 +1337,9 @@
       },
       "npmPkg": "expo-facebook",
       "npm": {
-        "downloads": 52016,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 53164,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1369,13 +1369,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-file-system",
         "fullName": "expo/expo",
@@ -1389,9 +1389,9 @@
       },
       "npmPkg": "expo-file-system",
       "npm": {
-        "downloads": 431869,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 442280,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1421,13 +1421,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-font",
         "fullName": "expo/expo",
@@ -1440,9 +1440,9 @@
       },
       "npmPkg": "expo-font",
       "npm": {
-        "downloads": 370425,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 377238,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1472,13 +1472,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-gl",
         "fullName": "expo/expo",
@@ -1493,9 +1493,9 @@
       },
       "npmPkg": "expo-gl",
       "npm": {
-        "downloads": 47534,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 48720,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1525,13 +1525,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-google-app-auth",
         "fullName": "expo/expo",
@@ -1544,9 +1544,9 @@
       },
       "npmPkg": "expo-google-app-auth",
       "npm": {
-        "downloads": 12257,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 12446,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1576,13 +1576,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-google-sign-in",
         "fullName": "expo/expo",
@@ -1599,9 +1599,9 @@
       },
       "npmPkg": "expo-google-sign-in",
       "npm": {
-        "downloads": 39301,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 40148,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1631,13 +1631,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-haptics",
         "fullName": "expo/expo",
@@ -1651,9 +1651,9 @@
       },
       "npmPkg": "expo-haptics",
       "npm": {
-        "downloads": 47964,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 49186,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1683,13 +1683,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-image-manipulator",
         "fullName": "expo/expo",
@@ -1702,9 +1702,9 @@
       },
       "npmPkg": "expo-image-manipulator",
       "npm": {
-        "downloads": 47775,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 49153,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1734,13 +1734,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-image-picker",
         "fullName": "expo/expo",
@@ -1755,9 +1755,9 @@
       },
       "npmPkg": "expo-image-picker",
       "npm": {
-        "downloads": 103223,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 106063,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1787,13 +1787,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-in-app-purchases",
         "fullName": "expo/expo",
@@ -1806,9 +1806,9 @@
       },
       "npmPkg": "expo-in-app-purchases",
       "npm": {
-        "downloads": 1367,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1408,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1838,13 +1838,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-intent-launcher",
         "fullName": "expo/expo",
@@ -1859,9 +1859,9 @@
       },
       "npmPkg": "expo-intent-launcher",
       "npm": {
-        "downloads": 47580,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 49040,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1891,13 +1891,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-keep-awake",
         "fullName": "expo/expo",
@@ -1911,9 +1911,9 @@
       },
       "npmPkg": "expo-keep-awake",
       "npm": {
-        "downloads": 350559,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 357975,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1943,13 +1943,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-linear-gradient",
         "fullName": "expo/expo",
@@ -1962,9 +1962,9 @@
       },
       "npmPkg": "expo-linear-gradient",
       "npm": {
-        "downloads": 350096,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 357317,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -1994,13 +1994,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-local-authentication",
         "fullName": "expo/expo",
@@ -2017,9 +2017,9 @@
       },
       "npmPkg": "expo-local-authentication",
       "npm": {
-        "downloads": 65950,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 67803,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2049,13 +2049,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-localization",
         "fullName": "expo/expo",
@@ -2070,9 +2070,9 @@
       },
       "npmPkg": "expo-localization",
       "npm": {
-        "downloads": 83164,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 85558,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2102,13 +2102,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-location",
         "fullName": "expo/expo",
@@ -2126,9 +2126,9 @@
       },
       "npmPkg": "expo-location",
       "npm": {
-        "downloads": 355359,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 362696,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2158,13 +2158,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-mail-composer",
         "fullName": "expo/expo",
@@ -2178,9 +2178,9 @@
       },
       "npmPkg": "expo-mail-composer",
       "npm": {
-        "downloads": 39978,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 40871,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2210,13 +2210,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-media-library",
         "fullName": "expo/expo",
@@ -2233,9 +2233,9 @@
       },
       "npmPkg": "expo-media-library",
       "npm": {
-        "downloads": 50815,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 52149,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2265,13 +2265,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-network",
         "fullName": "expo/expo",
@@ -2284,9 +2284,9 @@
       },
       "npmPkg": "expo-network",
       "npm": {
-        "downloads": 4258,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4382,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2316,13 +2316,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-notifications",
         "fullName": "expo/expo",
@@ -2336,9 +2336,9 @@
       },
       "npmPkg": "expo-notifications",
       "npm": {
-        "downloads": 1290,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1338,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2368,13 +2368,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-payments-stripe",
         "fullName": "expo/expo",
@@ -2389,9 +2389,9 @@
       },
       "npmPkg": "expo-payments-stripe",
       "npm": {
-        "downloads": 38162,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 39244,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2421,13 +2421,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-permissions",
         "fullName": "expo/expo",
@@ -2440,9 +2440,9 @@
       },
       "npmPkg": "expo-permissions",
       "npm": {
-        "downloads": 451969,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 463395,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2472,13 +2472,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-print",
         "fullName": "expo/expo",
@@ -2491,9 +2491,9 @@
       },
       "npmPkg": "expo-print",
       "npm": {
-        "downloads": 41266,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 42194,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2523,13 +2523,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-processing",
         "fullName": "expo/expo",
@@ -2544,9 +2544,9 @@
       },
       "npmPkg": "expo-processing",
       "npm": {
-        "downloads": 59,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 56,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2576,13 +2576,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-random",
         "fullName": "expo/expo",
@@ -2600,9 +2600,9 @@
       },
       "npmPkg": "expo-random",
       "npm": {
-        "downloads": 53505,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 55315,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2632,13 +2632,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-secure-store",
         "fullName": "expo/expo",
@@ -2653,9 +2653,9 @@
       },
       "npmPkg": "expo-secure-store",
       "npm": {
-        "downloads": 75981,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 78722,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2685,13 +2685,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-sensors",
         "fullName": "expo/expo",
@@ -2710,9 +2710,9 @@
       },
       "npmPkg": "expo-sensors",
       "npm": {
-        "downloads": 44015,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 45078,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2742,13 +2742,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-sms",
         "fullName": "expo/expo",
@@ -2761,9 +2761,9 @@
       },
       "npmPkg": "expo-sms",
       "npm": {
-        "downloads": 46564,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 47569,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2793,13 +2793,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-speech",
         "fullName": "expo/expo",
@@ -2814,9 +2814,9 @@
       },
       "npmPkg": "expo-speech",
       "npm": {
-        "downloads": 28681,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 29494,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2846,13 +2846,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-sqlite",
         "fullName": "expo/expo",
@@ -2867,9 +2867,9 @@
       },
       "npmPkg": "expo-sqlite",
       "npm": {
-        "downloads": 330925,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 337488,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2899,13 +2899,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-store-review",
         "fullName": "expo/expo",
@@ -2918,9 +2918,9 @@
       },
       "npmPkg": "expo-store-review",
       "npm": {
-        "downloads": 5551,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5743,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -2950,13 +2950,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-task-manager",
         "fullName": "expo/expo",
@@ -2971,9 +2971,9 @@
       },
       "npmPkg": "expo-task-manager",
       "npm": {
-        "downloads": 40846,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 41794,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3003,13 +3003,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-video-thumbnails",
         "fullName": "expo/expo",
@@ -3022,9 +3022,9 @@
       },
       "npmPkg": "expo-video-thumbnails",
       "npm": {
-        "downloads": 2104,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2171,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3054,13 +3054,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-web-browser",
         "fullName": "expo/expo",
@@ -3075,9 +3075,9 @@
       },
       "npmPkg": "expo-web-browser",
       "npm": {
-        "downloads": 395778,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 404565,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3107,22 +3107,22 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "jest-expo",
         "fullName": "expo/expo"
       },
       "npmPkg": "jest-expo",
       "npm": {
-        "downloads": 195914,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 201510,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3152,13 +3152,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "jest-expo-enzyme",
         "fullName": "expo/expo",
@@ -3175,9 +3175,9 @@
       },
       "npmPkg": "jest-expo-enzyme",
       "npm": {
-        "downloads": 12945,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 13346,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3207,22 +3207,22 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "jest-expo-puppeteer",
         "fullName": "expo/expo"
       },
       "npmPkg": "jest-expo-puppeteer",
       "npm": {
-        "downloads": 113,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 120,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3254,13 +3254,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-splash-screen",
         "fullName": "expo/expo",
@@ -3277,9 +3277,9 @@
       },
       "npmPkg": "expo-splash-screen",
       "npm": {
-        "downloads": 4161,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5279,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3311,13 +3311,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-updates",
         "fullName": "expo/expo",
@@ -3330,9 +3330,9 @@
       },
       "npmPkg": "expo-updates",
       "npm": {
-        "downloads": 47064,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 49221,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3364,13 +3364,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-auth-session",
         "fullName": "expo/expo",
@@ -3387,9 +3387,9 @@
       },
       "npmPkg": "expo-auth-session",
       "npm": {
-        "downloads": 4330,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4490,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3421,13 +3421,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-linking",
         "fullName": "expo/expo",
@@ -3440,9 +3440,9 @@
       },
       "npmPkg": "expo-linking",
       "npm": {
-        "downloads": 7483,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14461,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3474,13 +3474,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-screen-orientation",
         "fullName": "expo/expo",
@@ -3495,9 +3495,9 @@
       },
       "npmPkg": "expo-screen-orientation",
       "npm": {
-        "downloads": 8899,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 9268,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3529,13 +3529,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-sharing",
         "fullName": "expo/expo",
@@ -3548,9 +3548,9 @@
       },
       "npmPkg": "expo-sharing",
       "npm": {
-        "downloads": 35395,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 36417,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3583,13 +3583,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:21:11Z",
+          "updatedAt": "2020-05-12T18:12:34Z",
           "createdAt": "2016-08-15T17:14:25Z",
-          "pushedAt": "2020-05-11T23:21:07Z",
+          "pushedAt": "2020-05-12T18:12:30Z",
           "forks": 1495,
-          "issues": 867,
+          "issues": 872,
           "subscribers": 199,
-          "stars": 9732
+          "stars": 9749
         },
         "name": "expo-firebase-analytics",
         "fullName": "expo/expo",
@@ -3603,9 +3603,9 @@
         ]
       },
       "npm": {
-        "downloads": 5831,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6035,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -3616,6 +3616,2732 @@
         "Recently updated"
       ],
       "topicSearchString": " react-native expo expo-firebase firebase firebase-analytics"
+    },
+    {
+      "githubUrl": "https://github.com/invertase/react-native-firebase",
+      "ios": true,
+      "android": true,
+      "expo": false,
+      "web": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/invertase/react-native-firebase",
+          "clone": "https://github.com/invertase/react-native-firebase.git",
+          "homepage": "https://rnfirebase.io"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T18:06:51Z",
+          "createdAt": "2017-02-01T12:01:03Z",
+          "pushedAt": "2020-05-12T18:06:49Z",
+          "forks": 1363,
+          "issues": 150,
+          "subscribers": 155,
+          "stars": 7374
+        },
+        "name": "react-native-firebase",
+        "fullName": "invertase/react-native-firebase",
+        "description": "🔥 A well-tested feature-rich modular Firebase implementation for React Native. Supports both iOS & Android platforms for all Firebase services.",
+        "topics": [
+          "analytics",
+          "android",
+          "auth",
+          "crashlytics",
+          "database",
+          "fcm",
+          "firebase",
+          "firestore",
+          "ios",
+          "javascript",
+          "push-notifications",
+          "react",
+          "react-hooks",
+          "react-native",
+          "react-native-app",
+          "realtime-database",
+          "remote-config",
+          "storage",
+          "transactions",
+          "web-sdk"
+        ],
+        "license": {
+          "key": "other",
+          "name": "Other",
+          "spdx_id": "NOASSERTION",
+          "url": null,
+          "node_id": "MDc6TGljZW5zZTA="
+        }
+      },
+      "npmPkg": "react-native-firebase",
+      "npm": {
+        "downloads": 280774,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " analytics android auth crashlytics database fcm firebase firestore ios javascript push-notifications react react-hooks react-native react-native-app realtime-database remote-config storage transactions web-sdk"
+    },
+    {
+      "githubUrl": "https://github.com/akveo/react-native-ui-kitten",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/akveo/react-native-ui-kitten",
+          "clone": "https://github.com/akveo/react-native-ui-kitten.git",
+          "homepage": "https://akveo.github.io/react-native-ui-kitten/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T17:18:39Z",
+          "createdAt": "2016-12-20T08:22:38Z",
+          "pushedAt": "2020-05-12T17:34:02Z",
+          "forks": 730,
+          "issues": 25,
+          "subscribers": 127,
+          "stars": 6432
+        },
+        "name": "react-native-ui-kitten",
+        "fullName": "akveo/react-native-ui-kitten",
+        "description": ":boom: React Native UI Library based on Eva Design System  :new_moon_with_face::sparkles:Dark Mode",
+        "topics": [
+          "react",
+          "react-native",
+          "ui-kit"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-ui-kitten",
+      "npm": {
+        "downloads": 5446,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 88,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " react react-native ui-kit"
+    },
+    {
+      "githubUrl": "https://github.com/aws-amplify/amplify-js",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "windows": false,
+      "npmPkg": "aws-amplify",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/aws-amplify/amplify-js",
+          "clone": "https://github.com/aws-amplify/amplify-js.git",
+          "homepage": "https://docs.amplify.aws/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T18:05:50Z",
+          "createdAt": "2017-10-02T22:17:14Z",
+          "pushedAt": "2020-05-12T17:29:18Z",
+          "forks": 1284,
+          "issues": 651,
+          "subscribers": 180,
+          "stars": 6846
+        },
+        "name": "amplify-js",
+        "fullName": "aws-amplify/amplify-js",
+        "description": "A declarative JavaScript library for application development using cloud services.",
+        "topics": [
+          "amazon-cognito",
+          "analytics",
+          "aws",
+          "aws-apigateway",
+          "aws-cognito",
+          "aws-mobile",
+          "aws-mobilehub",
+          "aws-s3",
+          "cloud-service",
+          "cognito",
+          "javascript",
+          "metrics",
+          "mobile-analytics",
+          "pinpoint",
+          "pwa",
+          "react",
+          "react-native",
+          "storage"
+        ],
+        "license": {
+          "key": "apache-2.0",
+          "name": "Apache License 2.0",
+          "spdx_id": "Apache-2.0",
+          "url": "https://api.github.com/licenses/apache-2.0",
+          "node_id": "MDc6TGljZW5zZTI="
+        }
+      },
+      "npm": {
+        "downloads": 556614,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " amazon-cognito analytics aws aws-apigateway aws-cognito aws-mobile aws-mobilehub aws-s3 cloud-service cognito javascript metrics mobile-analytics pinpoint pwa react react-native storage"
+    },
+    {
+      "githubUrl": "https://github.com/aws-amplify/amplify-js/tree/master/packages/datastore",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "windows": false,
+      "npmPkg": "@aws-amplify/datastore",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/aws-amplify/amplify-js",
+          "clone": "https://github.com/aws-amplify/amplify-js.git",
+          "homepage": "https://aws-amplify.github.io/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T18:05:50Z",
+          "createdAt": "2017-10-02T22:17:14Z",
+          "pushedAt": "2020-05-12T17:29:18Z",
+          "forks": 1284,
+          "issues": 651,
+          "subscribers": 180,
+          "stars": 6846
+        },
+        "name": "@aws-amplify/datastore",
+        "fullName": "aws-amplify/amplify-js",
+        "description": "AppSyncLocal support for aws-amplify"
+      },
+      "npm": {
+        "downloads": 183155,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/aws-amplify/amplify-js/tree/master/packages/aws-amplify-react-native",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "windows": false,
+      "npmPkg": "aws-amplify-react-native",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/aws-amplify/amplify-js",
+          "clone": "https://github.com/aws-amplify/amplify-js.git"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T18:05:50Z",
+          "createdAt": "2017-10-02T22:17:14Z",
+          "pushedAt": "2020-05-12T17:29:18Z",
+          "forks": 1284,
+          "issues": 651,
+          "subscribers": 180,
+          "stars": 6846
+        },
+        "name": "aws-amplify-react-native",
+        "fullName": "aws-amplify/amplify-js",
+        "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications."
+      },
+      "npm": {
+        "downloads": 68552,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/aws-amplify/amplify-js/tree/master/packages/auth",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "windows": false,
+      "npmPkg": "@aws-amplify/auth",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/aws-amplify/amplify-js",
+          "clone": "https://github.com/aws-amplify/amplify-js.git",
+          "homepage": "https://aws-amplify.github.io/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T18:05:50Z",
+          "createdAt": "2017-10-02T22:17:14Z",
+          "pushedAt": "2020-05-12T17:29:18Z",
+          "forks": 1284,
+          "issues": 651,
+          "subscribers": 180,
+          "stars": 6846
+        },
+        "name": "@aws-amplify/auth",
+        "fullName": "aws-amplify/amplify-js",
+        "description": "Auth category of aws-amplify"
+      },
+      "npm": {
+        "downloads": 747917,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/aws-amplify/amplify-js/tree/master/packages/pushnotification",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "windows": false,
+      "npmPkg": "@aws-amplify/pushnotification",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/aws-amplify/amplify-js",
+          "clone": "https://github.com/aws-amplify/amplify-js.git",
+          "homepage": "https://aws-amplify.github.io/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T18:05:50Z",
+          "createdAt": "2017-10-02T22:17:14Z",
+          "pushedAt": "2020-05-12T17:29:18Z",
+          "forks": 1284,
+          "issues": 651,
+          "subscribers": 180,
+          "stars": 6846
+        },
+        "name": "@aws-amplify/pushnotification",
+        "fullName": "aws-amplify/amplify-js",
+        "description": "Push notifications category of aws-amplify"
+      },
+      "npm": {
+        "downloads": 25125,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/dooboolab/react-native-iap",
+      "ios": true,
+      "android": true,
+      "npmPkg": "react-native-iap",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/dooboolab/react-native-iap",
+          "clone": "https://github.com/dooboolab/react-native-iap.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T05:20:35Z",
+          "createdAt": "2017-10-22T00:31:20Z",
+          "pushedAt": "2020-05-12T17:11:15Z",
+          "forks": 293,
+          "issues": 56,
+          "subscribers": 24,
+          "stars": 1347
+        },
+        "name": "react-native-iap",
+        "fullName": "dooboolab/react-native-iap",
+        "description": "react-native native module for In App Purchase.",
+        "topics": [
+          "in-app-purchase",
+          "java",
+          "objective-c",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 50060,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 63,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " in-app-purchase java objective-c react-native"
+    },
+    {
+      "githubUrl": "https://github.com/microsoft/react-native-windows",
+      "windows": true,
+      "npmPkg": "react-native-windows",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/microsoft/react-native-windows",
+          "clone": "https://github.com/microsoft/react-native-windows.git",
+          "homepage": "http://facebook.github.io/react-native/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T16:27:14Z",
+          "createdAt": "2015-12-15T00:16:54Z",
+          "pushedAt": "2020-05-12T17:08:50Z",
+          "forks": 888,
+          "issues": 428,
+          "subscribers": 308,
+          "stars": 11466
+        },
+        "name": "react-native-windows",
+        "fullName": "microsoft/react-native-windows",
+        "description": "A framework for building native Windows apps with React.",
+        "topics": [
+          "dotnet",
+          "react",
+          "react-native",
+          "uwp",
+          "xbox"
+        ],
+        "license": {
+          "key": "other",
+          "name": "Other",
+          "spdx_id": "NOASSERTION",
+          "url": null,
+          "node_id": "MDc6TGljZW5zZTA="
+        }
+      },
+      "npm": {
+        "downloads": 54507,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " dotnet react react-native uwp xbox"
+    },
+    {
+      "githubUrl": "https://github.com/react-native-webrtc/react-native-callkeep",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "windows": false,
+      "examples": [
+        "https://github.com/wazo-pbx/wazo-react-native-demo"
+      ],
+      "unmaintained": false,
+      "npmPkg": "react-native-callkeep",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-webrtc/react-native-callkeep",
+          "clone": "https://github.com/react-native-webrtc/react-native-callkeep.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T17:07:29Z",
+          "createdAt": "2018-12-07T14:33:26Z",
+          "pushedAt": "2020-05-12T17:07:26Z",
+          "forks": 106,
+          "issues": 44,
+          "subscribers": 15,
+          "stars": 244
+        },
+        "name": "react-native-callkeep",
+        "fullName": "react-native-webrtc/react-native-callkeep",
+        "description": "iOS CallKit framework and Android ConnectionService for React Native",
+        "topics": [
+          "android",
+          "call-kit",
+          "callkit",
+          "connection-service",
+          "connectionservice",
+          "ios",
+          "react-native",
+          "voip",
+          "webrtc"
+        ],
+        "license": {
+          "key": "isc",
+          "name": "ISC License",
+          "spdx_id": "ISC",
+          "url": "https://api.github.com/licenses/isc",
+          "node_id": "MDc6TGljZW5zZTEw"
+        }
+      },
+      "npm": {
+        "downloads": 5108,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": " android call-kit callkit connection-service connectionservice ios react-native voip webrtc"
+    },
+    {
+      "githubUrl": "https://github.com/react-native-community/react-native-picker",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "windows": false,
+      "unmaintained": false,
+      "npmPkg": "@react-native-community/picker",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/react-native-picker",
+          "clone": "https://github.com/react-native-community/react-native-picker.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T16:58:40Z",
+          "createdAt": "2019-03-01T01:55:16Z",
+          "pushedAt": "2020-05-12T16:58:40Z",
+          "forks": 33,
+          "issues": 20,
+          "subscribers": 4,
+          "stars": 105
+        },
+        "name": "react-native-picker",
+        "fullName": "react-native-community/react-native-picker",
+        "description": "Picker is a cross-platform UI component for selecting an item from a list of options.",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 30794,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/iamacup/react-native-markdown-display",
+      "ios": true,
+      "android": true,
+      "npmPkg": "react-native-markdown-display",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/iamacup/react-native-markdown-display",
+          "clone": "https://github.com/iamacup/react-native-markdown-display.git",
+          "homepage": null
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T15:58:57Z",
+          "createdAt": "2019-10-29T12:10:24Z",
+          "pushedAt": "2020-05-12T16:54:09Z",
+          "forks": 10,
+          "issues": 10,
+          "subscribers": 1,
+          "stars": 54
+        },
+        "name": "react-native-markdown-display",
+        "fullName": "iamacup/react-native-markdown-display",
+        "description": "React Native 100% compatible CommonMark renderer",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 22120,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/react-native-community/google-signin",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "examples": [],
+      "npmPkg": "@react-native-community/google-signin",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/google-signin",
+          "clone": "https://github.com/react-native-community/google-signin.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T16:51:56Z",
+          "createdAt": "2015-08-13T06:13:57Z",
+          "pushedAt": "2020-05-12T16:51:53Z",
+          "forks": 701,
+          "issues": 29,
+          "subscribers": 45,
+          "stars": 1818
+        },
+        "name": "google-signin",
+        "fullName": "react-native-community/google-signin",
+        "description": "Google Sign-in for your React Native applications",
+        "topics": [
+          "googleauth",
+          "googlesignin",
+          "oauth2",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 88950,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 88,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " googleauth googlesignin oauth2 react-native"
+    },
+    {
+      "githubUrl": "https://github.com/react-native-community/react-native-cameraroll",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "windows": false,
+      "unmaintained": false,
+      "npmPkg": "@react-native-community/cameraroll",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/react-native-cameraroll",
+          "clone": "https://github.com/react-native-community/react-native-cameraroll.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T18:13:20Z",
+          "createdAt": "2019-02-07T10:52:08Z",
+          "pushedAt": "2020-05-12T15:53:32Z",
+          "forks": 126,
+          "issues": 34,
+          "subscribers": 8,
+          "stars": 207
+        },
+        "name": "react-native-cameraroll",
+        "fullName": "react-native-community/react-native-cameraroll",
+        "description": "CameraRoll is a react-native native module that provides access to the local camera roll or photo library.",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 112075,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 63,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/react-community/react-navigation",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "goldstar": true,
+      "examples": [
+        "https://snack.expo.io/rJnUK4nrZ"
+      ],
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-navigation/react-navigation",
+          "clone": "https://github.com/react-navigation/react-navigation.git",
+          "homepage": "https://reactnavigation.org"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T16:12:12Z",
+          "createdAt": "2017-01-26T19:51:40Z",
+          "pushedAt": "2020-05-12T15:48:06Z",
+          "forks": 3773,
+          "issues": 165,
+          "subscribers": 356,
+          "stars": 18086
+        },
+        "name": "react-navigation",
+        "fullName": "react-navigation/react-navigation",
+        "description": "Routing and navigation for your React Native apps",
+        "topics": [
+          "navigation",
+          "react",
+          "react-native",
+          "react-navigation"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-navigation",
+      "npm": {
+        "downloads": 930536,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 88,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recommended",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " navigation react react-native react-navigation"
+    },
+    {
+      "githubUrl": "https://github.com/react-native-community/async-storage",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "windows": true,
+      "unmaintained": false,
+      "npmPkg": "@react-native-community/async-storage",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/async-storage",
+          "clone": "https://github.com/react-native-community/async-storage.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T18:08:47Z",
+          "createdAt": "2019-02-06T15:51:20Z",
+          "pushedAt": "2020-05-12T15:37:37Z",
+          "forks": 229,
+          "issues": 26,
+          "subscribers": 23,
+          "stars": 1637
+        },
+        "name": "async-storage",
+        "fullName": "react-native-community/async-storage",
+        "description": "An asynchronous, persistent, key-value storage system for React Native.",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 902242,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 88,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/underscopeio/react-native-navigation-hooks",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "windows": false,
+      "npmPkg": "react-native-navigation-hooks",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/underscopeio/react-native-navigation-hooks",
+          "clone": "https://github.com/underscopeio/react-native-navigation-hooks.git",
+          "homepage": null
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T15:35:25Z",
+          "createdAt": "2019-06-10T00:29:58Z",
+          "pushedAt": "2020-05-12T15:35:22Z",
+          "forks": 9,
+          "issues": 0,
+          "subscribers": 8,
+          "stars": 112
+        },
+        "name": "react-native-navigation-hooks",
+        "fullName": "underscopeio/react-native-navigation-hooks",
+        "description": "A set of React hooks for React Native Navigation.",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 5663,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/wix/react-native-calendars",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "goldstar": true,
+      "examples": [
+        "https://snack.expo.io/HkoXUdhr-"
+      ],
+      "github": {
+        "urls": {
+          "repo": "https://github.com/wix/react-native-calendars",
+          "clone": "https://github.com/wix/react-native-calendars.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T10:28:42Z",
+          "createdAt": "2016-11-11T12:17:27Z",
+          "pushedAt": "2020-05-12T14:59:02Z",
+          "forks": 1665,
+          "issues": 444,
+          "subscribers": 356,
+          "stars": 5487
+        },
+        "name": "react-native-calendars",
+        "fullName": "wix/react-native-calendars",
+        "description": "React Native Calendar Components 🗓️ 📆 ",
+        "topics": [
+          "android",
+          "calendar",
+          "ios",
+          "react-native",
+          "ui-components"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-calendars",
+      "npm": {
+        "downloads": 141319,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 88,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recommended",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " android calendar ios react-native ui-components"
+    },
+    {
+      "githubUrl": "https://github.com/FortAwesome/react-native-fontawesome",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": true,
+      "windows": false,
+      "npmPkg": "@fortawesome/react-native-fontawesome",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/FortAwesome/react-native-fontawesome",
+          "clone": "https://github.com/FortAwesome/react-native-fontawesome.git",
+          "homepage": null
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-10T00:17:36Z",
+          "createdAt": "2018-10-02T20:16:03Z",
+          "pushedAt": "2020-05-12T14:57:48Z",
+          "forks": 22,
+          "issues": 14,
+          "subscribers": 7,
+          "stars": 149
+        },
+        "name": "react-native-fontawesome",
+        "fullName": "FortAwesome/react-native-fontawesome",
+        "description": "Official React Native component for Font Awesome 5",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 22481,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/wmcmahan/react-native-calendar-events",
+      "ios": true,
+      "android": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/wmcmahan/react-native-calendar-events",
+          "clone": "https://github.com/wmcmahan/react-native-calendar-events.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T16:03:42Z",
+          "createdAt": "2016-02-24T04:23:38Z",
+          "pushedAt": "2020-05-12T14:54:02Z",
+          "forks": 189,
+          "issues": 52,
+          "subscribers": 13,
+          "stars": 598
+        },
+        "name": "react-native-calendar-events",
+        "fullName": "wmcmahan/react-native-calendar-events",
+        "description": "📆 React Native Module for iOS and Android Calendar Events",
+        "topics": [
+          "alarms",
+          "andriod",
+          "andriod-sdk",
+          "android-calendar",
+          "android-calendar-api",
+          "android-calendar-events",
+          "calendar-api",
+          "calendar-events",
+          "ios-calendar",
+          "ios-calendar-api",
+          "ios-calendar-events",
+          "ios-library",
+          "ios-sdk",
+          "react-native",
+          "react-native-module",
+          "recurring-events"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-calendar-events",
+      "npm": {
+        "downloads": 23469,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 63,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " alarms andriod andriod-sdk android-calendar android-calendar-api android-calendar-events calendar-api calendar-events ios-calendar ios-calendar-api ios-calendar-events ios-library ios-sdk react-native react-native-module recurring-events"
+    },
+    {
+      "githubUrl": "https://github.com/software-mansion/react-native-reanimated",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/software-mansion/react-native-reanimated",
+          "clone": "https://github.com/software-mansion/react-native-reanimated.git",
+          "homepage": "https://software-mansion.github.io/react-native-reanimated"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T13:08:08Z",
+          "createdAt": "2018-04-25T06:35:29Z",
+          "pushedAt": "2020-05-12T14:38:31Z",
+          "forks": 344,
+          "issues": 138,
+          "subscribers": 39,
+          "stars": 2853
+        },
+        "name": "react-native-reanimated",
+        "fullName": "software-mansion/react-native-reanimated",
+        "description": "React Native's Animated library reimplemented",
+        "topics": [
+          "animation",
+          "gesture",
+          "javascript",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-reanimated",
+      "npm": {
+        "downloads": 978710,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " animation gesture javascript react-native"
+    },
+    {
+      "githubUrl": "https://github.com/react-native-community/react-native-webview",
+      "ios": true,
+      "android": true,
+      "expo": true,
+      "web": false,
+      "windows": true,
+      "macos": true,
+      "npmPkg": "react-native-webview",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/react-native-webview",
+          "clone": "https://github.com/react-native-community/react-native-webview.git",
+          "homepage": "https://github.com/react-native-community/discussions-and-proposals/pull/3"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T08:22:23Z",
+          "createdAt": "2018-09-09T00:14:44Z",
+          "pushedAt": "2020-05-12T14:26:51Z",
+          "forks": 1202,
+          "issues": 143,
+          "subscribers": 36,
+          "stars": 2557
+        },
+        "name": "react-native-webview",
+        "fullName": "react-native-community/react-native-webview",
+        "description": "React Native Cross-Platform WebView",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 762556,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/react-native-community/react-native-camera",
+      "ios": true,
+      "android": true,
+      "expo": false,
+      "web": false,
+      "windows": false,
+      "npmPkg": "react-native-camera",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/react-native-camera",
+          "clone": "https://github.com/react-native-community/react-native-camera.git",
+          "homepage": "https://react-native-community.github.io/react-native-camera/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T05:33:20Z",
+          "createdAt": "2015-04-01T00:54:40Z",
+          "pushedAt": "2020-05-12T14:21:08Z",
+          "forks": 2718,
+          "issues": 111,
+          "subscribers": 195,
+          "stars": 8379
+        },
+        "name": "react-native-camera",
+        "fullName": "react-native-community/react-native-camera",
+        "description": "A Camera component for React Native. Also supports barcode scanning!",
+        "topics": [
+          "camera",
+          "face-detection",
+          "react-native",
+          "rncamera"
+        ],
+        "license": {
+          "key": "other",
+          "name": "Other",
+          "spdx_id": "NOASSERTION",
+          "url": null,
+          "node_id": "MDc6TGljZW5zZTA="
+        }
+      },
+      "npm": {
+        "downloads": 287056,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " camera face-detection react-native rncamera"
+    },
+    {
+      "githubUrl": "https://github.com/react-native-community/react-native-checkbox",
+      "ios": false,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "examples": [],
+      "npmPkg": "@react-native-community/checkbox",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/react-native-checkbox",
+          "clone": "https://github.com/react-native-community/react-native-checkbox.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T06:01:18Z",
+          "createdAt": "2019-02-06T17:44:24Z",
+          "pushedAt": "2020-05-12T14:19:52Z",
+          "forks": 15,
+          "issues": 7,
+          "subscribers": 4,
+          "stars": 78
+        },
+        "name": "react-native-checkbox",
+        "fullName": "react-native-community/react-native-checkbox",
+        "description": "Checkbox component for React Native",
+        "topics": [
+          "checkbox",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 15360,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": " checkbox react-native"
+    },
+    {
+      "githubUrl": "https://github.com/FaridSafi/react-native-google-places-autocomplete",
+      "ios": true,
+      "android": true,
+      "expo": true,
+      "examples": [
+        "https://snack.expo.io/Skd57d2r-"
+      ],
+      "github": {
+        "urls": {
+          "repo": "https://github.com/FaridSafi/react-native-google-places-autocomplete",
+          "clone": "https://github.com/FaridSafi/react-native-google-places-autocomplete.git",
+          "homepage": null
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T18:04:36Z",
+          "createdAt": "2015-10-14T17:29:41Z",
+          "pushedAt": "2020-05-12T13:59:38Z",
+          "forks": 583,
+          "issues": 98,
+          "subscribers": 22,
+          "stars": 1229
+        },
+        "name": "react-native-google-places-autocomplete",
+        "fullName": "FaridSafi/react-native-google-places-autocomplete",
+        "description": "Customizable Google Places autocomplete component for iOS and Android React-Native apps",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-google-places-autocomplete",
+      "npm": {
+        "downloads": 52428,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 50,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/software-mansion/react-native-screens",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "windows": false,
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/software-mansion/react-native-screens",
+          "clone": "https://github.com/software-mansion/react-native-screens.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T11:54:09Z",
+          "createdAt": "2018-08-03T11:36:32Z",
+          "pushedAt": "2020-05-12T11:54:07Z",
+          "forks": 178,
+          "issues": 114,
+          "subscribers": 29,
+          "stars": 1343
+        },
+        "name": "react-native-screens",
+        "fullName": "software-mansion/react-native-screens",
+        "description": "Native navigation primitives for your React Native app.",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-screens",
+      "npm": {
+        "downloads": 1272363,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/Nozbe/WatermelonDB",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": false,
+      "npmPkg": "@nozbe/watermelondb",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/Nozbe/WatermelonDB",
+          "clone": "https://github.com/Nozbe/WatermelonDB.git",
+          "homepage": "https://nozbe.github.io/WatermelonDB/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T17:47:43Z",
+          "createdAt": "2018-08-28T15:32:05Z",
+          "pushedAt": "2020-05-12T10:45:22Z",
+          "forks": 315,
+          "issues": 71,
+          "subscribers": 111,
+          "stars": 6611
+        },
+        "name": "WatermelonDB",
+        "fullName": "Nozbe/WatermelonDB",
+        "description": "🍉 Reactive & asynchronous database for powerful React and React Native apps ⚡️",
+        "topics": [
+          "database",
+          "persistence",
+          "react",
+          "react-native",
+          "reactive",
+          "rxjs"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 6128,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 88,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " database persistence react react-native reactive rxjs"
+    },
+    {
+      "githubUrl": "https://github.com/getsentry/sentry-react-native",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": true,
+      "windows": false,
+      "npmPkg": "@sentry/react-native",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/getsentry/sentry-react-native",
+          "clone": "https://github.com/getsentry/sentry-react-native.git",
+          "homepage": "https://sentry.io"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T10:03:27Z",
+          "createdAt": "2016-11-30T14:45:57Z",
+          "pushedAt": "2020-05-12T10:03:25Z",
+          "forks": 205,
+          "issues": 60,
+          "subscribers": 48,
+          "stars": 833
+        },
+        "name": "sentry-react-native",
+        "fullName": "getsentry/sentry-react-native",
+        "description": "Official Sentry SDK for react-native",
+        "topics": [
+          "android",
+          "crash",
+          "ios",
+          "javascript",
+          "mixed-stacktraces",
+          "raven-js",
+          "react",
+          "react-native",
+          "sdk",
+          "sentry"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 326631,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 63,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " android crash ios javascript mixed-stacktraces raven-js react react-native sdk sentry"
+    },
+    {
+      "githubUrl": "https://github.com/artyorsh/react-native-eva-icons",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/artyorsh/react-native-eva-icons",
+          "clone": "https://github.com/artyorsh/react-native-eva-icons.git",
+          "homepage": "https://github.com/akveo/eva-icons"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T09:54:42Z",
+          "createdAt": "2019-05-26T14:37:53Z",
+          "pushedAt": "2020-05-12T09:54:33Z",
+          "forks": 5,
+          "issues": 3,
+          "subscribers": 4,
+          "stars": 133
+        },
+        "name": "react-native-eva-icons",
+        "fullName": "artyorsh/react-native-eva-icons",
+        "description": "⭐Eva Icons for React Native",
+        "topics": [
+          "eva-icons",
+          "icons-source",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-eva-icons",
+      "npm": {
+        "downloads": 16511,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": " eva-icons icons-source react-native"
+    },
+    {
+      "githubUrl": "https://github.com/react-native-community/react-native-tab-view",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": true,
+      "goldstar": true,
+      "examples": [
+        "https://snack.expo.io/HJjbO4nSW",
+        "https://expo.io/@satya164/react-native-tab-view-demos"
+      ],
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/react-native-tab-view",
+          "clone": "https://github.com/react-native-community/react-native-tab-view.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T16:04:03Z",
+          "createdAt": "2016-06-15T21:38:19Z",
+          "pushedAt": "2020-05-12T09:36:31Z",
+          "forks": 812,
+          "issues": 30,
+          "subscribers": 52,
+          "stars": 3851
+        },
+        "name": "react-native-tab-view",
+        "fullName": "react-native-community/react-native-tab-view",
+        "description": "A cross-platform Tab View component for React Native",
+        "topics": [
+          "pager-component",
+          "react-native",
+          "swipe",
+          "swipeview",
+          "tabbar",
+          "tabs"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-tab-view",
+      "npm": {
+        "downloads": 1143682,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 100,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recommended",
+        "Recently updated"
+      ],
+      "topicSearchString": " pager-component react-native swipe swipeview tabbar tabs"
+    },
+    {
+      "githubUrl": "https://github.com/shoutem/ui",
+      "ios": true,
+      "android": true,
+      "expo": true,
+      "npmPkg": "@shoutem/ui",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/shoutem/ui",
+          "clone": "https://github.com/shoutem/ui.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T09:14:53Z",
+          "createdAt": "2016-08-08T15:26:08Z",
+          "pushedAt": "2020-05-12T09:16:29Z",
+          "forks": 526,
+          "issues": 105,
+          "subscribers": 109,
+          "stars": 4547
+        },
+        "name": "ui",
+        "fullName": "shoutem/ui",
+        "description": "Customizable set of components for React Native applications",
+        "topics": [
+          "android",
+          "ios",
+          "native-components",
+          "react-native",
+          "shoutem",
+          "shoutem-ui"
+        ],
+        "license": {
+          "key": "other",
+          "name": "Other",
+          "spdx_id": "NOASSERTION",
+          "url": null,
+          "node_id": "MDc6TGljZW5zZTA="
+        }
+      },
+      "npm": {
+        "downloads": 2150,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 75,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " android ios native-components react-native shoutem shoutem-ui"
+    },
+    {
+      "githubUrl": "https://github.com/stephy/CalendarPicker",
+      "ios": true,
+      "android": true,
+      "expo": true,
+      "npmPkg": "react-native-calendar-picker",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/stephy/CalendarPicker",
+          "clone": "https://github.com/stephy/CalendarPicker.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T16:46:57Z",
+          "createdAt": "2015-04-12T06:11:27Z",
+          "pushedAt": "2020-05-12T08:53:19Z",
+          "forks": 232,
+          "issues": 17,
+          "subscribers": 12,
+          "stars": 490
+        },
+        "name": "CalendarPicker",
+        "fullName": "stephy/CalendarPicker",
+        "description": "CalendarPicker Component for React Native",
+        "topics": [
+          "calendar",
+          "calendar-picker-component",
+          "calendarpicker",
+          "react-native-calendar-picker",
+          "react-native-component"
+        ],
+        "license": null
+      },
+      "npm": {
+        "downloads": 8767,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 63,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " calendar calendar-picker-component calendarpicker react-native-calendar-picker react-native-component"
+    },
+    {
+      "githubUrl": "https://github.com/GetStream/stream-chat-react-native",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/GetStream/stream-chat-react-native",
+          "clone": "https://github.com/GetStream/stream-chat-react-native.git",
+          "homepage": "https://getstream.io/chat/react-native-chat/tutorial/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T08:52:22Z",
+          "createdAt": "2019-03-28T08:50:26Z",
+          "pushedAt": "2020-05-12T08:52:19Z",
+          "forks": 51,
+          "issues": 25,
+          "subscribers": 18,
+          "stars": 105
+        },
+        "name": "stream-chat-react-native",
+        "fullName": "GetStream/stream-chat-react-native",
+        "description": "Stream Chat official react-native SDK. The tutorial covers how to build your own chat experience using react-native, react-navigation and Stream",
+        "topics": [],
+        "license": {
+          "key": "other",
+          "name": "Other",
+          "spdx_id": "NOASSERTION",
+          "url": null,
+          "node_id": "MDc6TGljZW5zZTA="
+        }
+      },
+      "npmPkg": "stream-chat-react-native",
+      "npm": {
+        "downloads": 6398,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/react-native-kit/react-native-track-player",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-kit/react-native-track-player",
+          "clone": "https://github.com/react-native-kit/react-native-track-player.git",
+          "homepage": "https://react-native-track-player.js.org/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-11T14:11:19Z",
+          "createdAt": "2017-03-16T20:18:39Z",
+          "pushedAt": "2020-05-12T08:50:49Z",
+          "forks": 411,
+          "issues": 207,
+          "subscribers": 47,
+          "stars": 1311
+        },
+        "name": "react-native-track-player",
+        "fullName": "react-native-kit/react-native-track-player",
+        "description": "A fully fledged audio module created for music apps. Provides audio playback, external media controls, chromecast support, background mode and more!",
+        "topics": [
+          "android",
+          "ios",
+          "media-control",
+          "music-library",
+          "music-player",
+          "react-native",
+          "windows"
+        ],
+        "license": {
+          "key": "apache-2.0",
+          "name": "Apache License 2.0",
+          "spdx_id": "Apache-2.0",
+          "url": "https://api.github.com/licenses/apache-2.0",
+          "node_id": "MDc6TGljZW5zZTI="
+        }
+      },
+      "npmPkg": "react-native-track-player",
+      "npm": {
+        "downloads": 15850,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 50,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " android ios media-control music-library music-player react-native windows"
+    },
+    {
+      "githubUrl": "https://github.com/FaridSafi/react-native-gifted-chat",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "examples": [
+        "https://snack.expo.io/@xcarpentier/giftedchat-playground",
+        "https://reverent-bardeen-47c862.netlify.app/"
+      ],
+      "npmPkg": "react-native-gifted-chat",
+      "github": {
+        "urls": {
+          "repo": "https://github.com/FaridSafi/react-native-gifted-chat",
+          "clone": "https://github.com/FaridSafi/react-native-gifted-chat.git",
+          "homepage": "https://gifted.chat"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T17:05:46Z",
+          "createdAt": "2015-11-14T15:45:34Z",
+          "pushedAt": "2020-05-12T08:03:03Z",
+          "forks": 2708,
+          "issues": 46,
+          "subscribers": 205,
+          "stars": 9188
+        },
+        "name": "react-native-gifted-chat",
+        "fullName": "FaridSafi/react-native-gifted-chat",
+        "description": "💬 The most complete chat UI for React Native",
+        "topics": [
+          "chat",
+          "component",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 67880,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 88,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " chat component react-native"
+    },
+    {
+      "githubUrl": "https://github.com/wix/react-native-navigation",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "goldstar": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/wix/react-native-navigation",
+          "clone": "https://github.com/wix/react-native-navigation.git",
+          "homepage": "https://wix.github.io/react-native-navigation/"
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": true,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T16:13:07Z",
+          "createdAt": "2016-03-11T11:22:54Z",
+          "pushedAt": "2020-05-12T07:48:28Z",
+          "forks": 2551,
+          "issues": 137,
+          "subscribers": 521,
+          "stars": 11450
+        },
+        "name": "react-native-navigation",
+        "fullName": "wix/react-native-navigation",
+        "description": "A complete native navigation solution for React Native",
+        "topics": [
+          "navigation",
+          "navigator",
+          "react-native",
+          "react-native-navigation"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-navigation",
+      "npm": {
+        "downloads": 123285,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 88,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recommended",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " navigation navigator react-native react-native-navigation"
+    },
+    {
+      "githubUrl": "https://github.com/netguru/sticky-parallax-header",
+      "examples": [
+        "https://github.com/netguru/sticky-parallax-header/tree/master/example"
+      ],
+      "npmPkg": "react-native-sticky-parallax-header",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": true,
+      "windows": false,
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/netguru/sticky-parallax-header",
+          "clone": "https://github.com/netguru/sticky-parallax-header.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T10:40:25Z",
+          "createdAt": "2019-04-30T07:18:03Z",
+          "pushedAt": "2020-05-12T07:32:42Z",
+          "forks": 40,
+          "issues": 11,
+          "subscribers": 14,
+          "stars": 284
+        },
+        "name": "sticky-parallax-header",
+        "fullName": "netguru/sticky-parallax-header",
+        "description": "A simple React Native library, enabling to create a fully custom header for your iOS and Android apps.",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 1063,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/airbnb/react-native-maps",
+      "ios": true,
+      "android": true,
+      "expo": true,
+      "examples": [
+        "https://snack.expo.io/H1zOFxnN-"
+      ],
+      "goldstar": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/react-native-maps",
+          "clone": "https://github.com/react-native-community/react-native-maps.git",
+          "homepage": null
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T16:53:10Z",
+          "createdAt": "2015-12-29T19:54:20Z",
+          "pushedAt": "2020-05-12T07:23:10Z",
+          "forks": 3718,
+          "issues": 346,
+          "subscribers": 248,
+          "stars": 11025
+        },
+        "name": "react-native-maps",
+        "fullName": "react-native-community/react-native-maps",
+        "description": "React Native Mapview component for iOS + Android",
+        "topics": [
+          "google-maps",
+          "maps",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-maps",
+      "npm": {
+        "downloads": 383517,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 88,
+      "matchingScoreModifiers": [
+        "Very popular",
+        "Popular",
+        "Recommended",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " google-maps maps react-native"
+    },
+    {
+      "githubUrl": "https://github.com/ascoders/react-native-image-viewer",
+      "ios": true,
+      "android": true,
+      "expo": true,
+      "npmPkg": "react-native-image-zoom-viewer",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/ascoders/react-native-image-viewer",
+          "clone": "https://github.com/ascoders/react-native-image-viewer.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T12:58:01Z",
+          "createdAt": "2016-09-13T13:43:44Z",
+          "pushedAt": "2020-05-12T07:23:03Z",
+          "forks": 409,
+          "issues": 125,
+          "subscribers": 21,
+          "stars": 1814
+        },
+        "name": "react-native-image-viewer",
+        "fullName": "ascoders/react-native-image-viewer",
+        "description": "🚀 tiny & fast lib for react native image viewer pan and zoom",
+        "topics": [
+          "image-viewer",
+          "react-component",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {
+        "downloads": 85024,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 50,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " image-viewer react-component react-native"
+    },
+    {
+      "githubUrl": "https://github.com/react-native-community/react-native-viewpager",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "windows": false,
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/react-native-community/react-native-viewpager",
+          "clone": "https://github.com/react-native-community/react-native-viewpager.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T08:37:55Z",
+          "createdAt": "2019-02-06T16:17:45Z",
+          "pushedAt": "2020-05-12T06:49:13Z",
+          "forks": 108,
+          "issues": 37,
+          "subscribers": 16,
+          "stars": 571
+        },
+        "name": "react-native-viewpager",
+        "fullName": "react-native-community/react-native-viewpager",
+        "description": "React Native wrapper for the Android ViewPager and iOS UIPageViewController.",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-viewpager",
+      "npm": {
+        "downloads": 4922,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": ""
+    },
+    {
+      "githubUrl": "https://github.com/evollu/react-native-fcm",
+      "ios": true,
+      "android": true,
+      "expo": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/evollu/react-native-fcm",
+          "clone": "https://github.com/evollu/react-native-fcm.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-11T08:56:53Z",
+          "createdAt": "2016-05-29T03:53:22Z",
+          "pushedAt": "2020-05-12T05:40:37Z",
+          "forks": 709,
+          "issues": 298,
+          "subscribers": 42,
+          "stars": 1718
+        },
+        "name": "react-native-fcm",
+        "fullName": "evollu/react-native-fcm",
+        "description": "react native module for firebase cloud messaging and local notification",
+        "topics": [
+          "android",
+          "fcm",
+          "firebase",
+          "ios",
+          "local-notifications",
+          "notifications"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-fcm",
+      "npm": {
+        "downloads": 13020,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 50,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " android fcm firebase ios local-notifications notifications"
+    },
+    {
+      "githubUrl": "https://github.com/Purii/react-native-tableview-simple",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/Purii/react-native-tableview-simple",
+          "clone": "https://github.com/Purii/react-native-tableview-simple.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-03T09:07:14Z",
+          "createdAt": "2015-10-25T21:05:29Z",
+          "pushedAt": "2020-05-12T04:56:06Z",
+          "forks": 58,
+          "issues": 8,
+          "subscribers": 11,
+          "stars": 321
+        },
+        "name": "react-native-tableview-simple",
+        "fullName": "Purii/react-native-tableview-simple",
+        "description": "Flexible and lightweight React Native component for UITableView made with pure CSS",
+        "topics": [
+          "css",
+          "ios",
+          "javascript",
+          "react",
+          "react-native",
+          "tableview",
+          "uitableview"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-tableview-simple",
+      "npm": {
+        "downloads": 3900,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": " css ios javascript react react-native tableview uitableview"
+    },
+    {
+      "githubUrl": "https://github.com/sbycrosz/react-native-credit-card-input",
+      "ios": true,
+      "android": true,
+      "expo": true,
+      "examples": [
+        "https://snack.expo.io/rJ7q6PhSb"
+      ],
+      "github": {
+        "urls": {
+          "repo": "https://github.com/sbycrosz/react-native-credit-card-input",
+          "clone": "https://github.com/sbycrosz/react-native-credit-card-input.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": false,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T18:07:08Z",
+          "createdAt": "2016-09-01T05:39:55Z",
+          "pushedAt": "2020-05-12T04:00:40Z",
+          "forks": 499,
+          "issues": 77,
+          "subscribers": 24,
+          "stars": 1088
+        },
+        "name": "react-native-credit-card-input",
+        "fullName": "sbycrosz/react-native-credit-card-input",
+        "description": "Easy, cross-platform credit-card input for your React Native Project! Start accepting payment 💰 in your app today!",
+        "topics": [
+          "android",
+          "component",
+          "credit-card",
+          "ios",
+          "payment",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-credit-card-input",
+      "npm": {
+        "downloads": 22065,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 50,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " android component credit-card ios payment react-native"
+    },
+    {
+      "githubUrl": "https://github.com/BugiDev/react-native-calendar-strip",
+      "ios": true,
+      "android": true,
+      "expo": true,
+      "examples": [
+        "https://snack.expo.io/By-aQF8LZ"
+      ],
+      "github": {
+        "urls": {
+          "repo": "https://github.com/BugiDev/react-native-calendar-strip",
+          "clone": "https://github.com/BugiDev/react-native-calendar-strip.git",
+          "homepage": null
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T01:37:42Z",
+          "createdAt": "2016-08-29T15:04:01Z",
+          "pushedAt": "2020-05-12T01:37:40Z",
+          "forks": 153,
+          "issues": 32,
+          "subscribers": 13,
+          "stars": 452
+        },
+        "name": "react-native-calendar-strip",
+        "fullName": "BugiDev/react-native-calendar-strip",
+        "description": "Easy to use and visually stunning calendar component for React Native.",
+        "topics": [
+          "calendar",
+          "calendar-strip",
+          "javascript",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-calendar-strip",
+      "npm": {
+        "downloads": 6612,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": " calendar calendar-strip javascript react-native"
+    },
+    {
+      "githubUrl": "https://github.com/oblador/react-native-keychain",
+      "ios": true,
+      "android": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/oblador/react-native-keychain",
+          "clone": "https://github.com/oblador/react-native-keychain.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-12T10:47:09Z",
+          "createdAt": "2015-05-20T15:33:48Z",
+          "pushedAt": "2020-05-12T01:01:53Z",
+          "forks": 303,
+          "issues": 66,
+          "subscribers": 26,
+          "stars": 1706
+        },
+        "name": "react-native-keychain",
+        "fullName": "oblador/react-native-keychain",
+        "description": ":key: Keychain Access for React Native",
+        "topics": [
+          "android",
+          "ios",
+          "keychain-access",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-keychain",
+      "npm": {
+        "downloads": 189994,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 63,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " android ios keychain-access react-native"
+    },
+    {
+      "githubUrl": "https://github.com/davodesign84/react-native-mixpanel",
+      "ios": true,
+      "android": true,
+      "web": false,
+      "expo": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/davodesign84/react-native-mixpanel",
+          "clone": "https://github.com/davodesign84/react-native-mixpanel.git",
+          "homepage": null
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-06T08:52:39Z",
+          "createdAt": "2015-11-11T00:10:10Z",
+          "pushedAt": "2020-05-11T23:49:21Z",
+          "forks": 192,
+          "issues": 59,
+          "subscribers": 14,
+          "stars": 411
+        },
+        "name": "react-native-mixpanel",
+        "fullName": "davodesign84/react-native-mixpanel",
+        "description": "A React Native wrapper for Mixpanel tracking",
+        "topics": [
+          "android",
+          "ios-app",
+          "java",
+          "mixpanel-ios-sdk",
+          "mixpanel-sdk",
+          "mobile-app",
+          "notifications",
+          "react-native",
+          "xcode"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "react-native-mixpanel",
+      "npm": {
+        "downloads": 76948,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 63,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Recently updated"
+      ],
+      "topicSearchString": " android ios-app java mixpanel-ios-sdk mixpanel-sdk mobile-app notifications react-native xcode"
+    },
+    {
+      "githubUrl": "https://github.com/FormidableLabs/victory-native",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/FormidableLabs/victory-native",
+          "clone": "https://github.com/FormidableLabs/victory-native.git",
+          "homepage": null
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": true,
+          "updatedAt": "2020-05-11T06:40:42Z",
+          "createdAt": "2016-07-22T21:45:58Z",
+          "pushedAt": "2020-05-11T23:24:21Z",
+          "forks": 133,
+          "issues": 105,
+          "subscribers": 51,
+          "stars": 1672
+        },
+        "name": "victory-native",
+        "fullName": "FormidableLabs/victory-native",
+        "description": "victory components for react native",
+        "topics": [
+          "charts",
+          "d3",
+          "data-visualization",
+          "react",
+          "react-native"
+        ],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npmPkg": "victory-native",
+      "npm": {
+        "downloads": 80764,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
+        "period": "month"
+      },
+      "score": 50,
+      "matchingScoreModifiers": [
+        "Popular",
+        "Lots of open issues",
+        "Recently updated"
+      ],
+      "topicSearchString": " charts d3 data-visualization react react-native"
     },
     {
       "githubUrl": "https://github.com/maggialejandro/react-native-calendario",
@@ -3664,9 +6390,9 @@
       },
       "npmPkg": "react-native-calendario",
       "npm": {
-        "downloads": 1014,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1029,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -3674,697 +6400,6 @@
         "Recently updated"
       ],
       "topicSearchString": " android calendar ios react-native"
-    },
-    {
-      "githubUrl": "https://github.com/FaridSafi/react-native-gifted-chat",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "examples": [
-        "https://snack.expo.io/@xcarpentier/giftedchat-playground",
-        "https://reverent-bardeen-47c862.netlify.app/"
-      ],
-      "npmPkg": "react-native-gifted-chat",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/FaridSafi/react-native-gifted-chat",
-          "clone": "https://github.com/FaridSafi/react-native-gifted-chat.git",
-          "homepage": "https://gifted.chat"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T17:16:02Z",
-          "createdAt": "2015-11-14T15:45:34Z",
-          "pushedAt": "2020-05-11T23:19:16Z",
-          "forks": 2707,
-          "issues": 44,
-          "subscribers": 205,
-          "stars": 9182
-        },
-        "name": "react-native-gifted-chat",
-        "fullName": "FaridSafi/react-native-gifted-chat",
-        "description": "💬 The most complete chat UI for React Native",
-        "topics": [
-          "chat",
-          "component",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 66093,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " chat component react-native"
-    },
-    {
-      "githubUrl": "https://github.com/FormidableLabs/victory-native",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/FormidableLabs/victory-native",
-          "clone": "https://github.com/FormidableLabs/victory-native.git",
-          "homepage": null
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T06:40:42Z",
-          "createdAt": "2016-07-22T21:45:58Z",
-          "pushedAt": "2020-05-11T23:18:49Z",
-          "forks": 133,
-          "issues": 104,
-          "subscribers": 51,
-          "stars": 1672
-        },
-        "name": "victory-native",
-        "fullName": "FormidableLabs/victory-native",
-        "description": "victory components for react native",
-        "topics": [
-          "charts",
-          "d3",
-          "data-visualization",
-          "react",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "victory-native",
-      "npm": {
-        "downloads": 77897,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 50,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " charts d3 data-visualization react react-native"
-    },
-    {
-      "githubUrl": "https://github.com/react-community/react-navigation",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "goldstar": true,
-      "examples": [
-        "https://snack.expo.io/rJnUK4nrZ"
-      ],
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-navigation/react-navigation",
-          "clone": "https://github.com/react-navigation/react-navigation.git",
-          "homepage": "https://reactnavigation.org"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T21:03:12Z",
-          "createdAt": "2017-01-26T19:51:40Z",
-          "pushedAt": "2020-05-11T22:57:54Z",
-          "forks": 3767,
-          "issues": 172,
-          "subscribers": 355,
-          "stars": 18085
-        },
-        "name": "react-navigation",
-        "fullName": "react-navigation/react-navigation",
-        "description": "Routing and navigation for your React Native apps",
-        "topics": [
-          "navigation",
-          "react",
-          "react-native",
-          "react-navigation"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-navigation",
-      "npm": {
-        "downloads": 903853,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recommended",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " navigation react react-native react-navigation"
-    },
-    {
-      "githubUrl": "https://github.com/FaridSafi/react-native-google-places-autocomplete",
-      "ios": true,
-      "android": true,
-      "expo": true,
-      "examples": [
-        "https://snack.expo.io/Skd57d2r-"
-      ],
-      "github": {
-        "urls": {
-          "repo": "https://github.com/FaridSafi/react-native-google-places-autocomplete",
-          "clone": "https://github.com/FaridSafi/react-native-google-places-autocomplete.git",
-          "homepage": null
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T02:41:08Z",
-          "createdAt": "2015-10-14T17:29:41Z",
-          "pushedAt": "2020-05-11T22:50:50Z",
-          "forks": 582,
-          "issues": 103,
-          "subscribers": 22,
-          "stars": 1227
-        },
-        "name": "react-native-google-places-autocomplete",
-        "fullName": "FaridSafi/react-native-google-places-autocomplete",
-        "description": "Customizable Google Places autocomplete component for iOS and Android React-Native apps",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-google-places-autocomplete",
-      "npm": {
-        "downloads": 51015,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 50,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/aws-amplify/amplify-js",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "windows": false,
-      "npmPkg": "aws-amplify",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/aws-amplify/amplify-js",
-          "clone": "https://github.com/aws-amplify/amplify-js.git",
-          "homepage": "https://docs.amplify.aws/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T22:34:16Z",
-          "createdAt": "2017-10-02T22:17:14Z",
-          "pushedAt": "2020-05-11T22:37:53Z",
-          "forks": 1283,
-          "issues": 647,
-          "subscribers": 180,
-          "stars": 6841
-        },
-        "name": "amplify-js",
-        "fullName": "aws-amplify/amplify-js",
-        "description": "A declarative JavaScript library for application development using cloud services.",
-        "topics": [
-          "amazon-cognito",
-          "analytics",
-          "aws",
-          "aws-apigateway",
-          "aws-cognito",
-          "aws-mobile",
-          "aws-mobilehub",
-          "aws-s3",
-          "cloud-service",
-          "cognito",
-          "javascript",
-          "metrics",
-          "mobile-analytics",
-          "pinpoint",
-          "pwa",
-          "react",
-          "react-native",
-          "storage"
-        ],
-        "license": {
-          "key": "apache-2.0",
-          "name": "Apache License 2.0",
-          "spdx_id": "Apache-2.0",
-          "url": "https://api.github.com/licenses/apache-2.0",
-          "node_id": "MDc6TGljZW5zZTI="
-        }
-      },
-      "npm": {
-        "downloads": 538872,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " amazon-cognito analytics aws aws-apigateway aws-cognito aws-mobile aws-mobilehub aws-s3 cloud-service cognito javascript metrics mobile-analytics pinpoint pwa react react-native storage"
-    },
-    {
-      "githubUrl": "https://github.com/aws-amplify/amplify-js/tree/master/packages/datastore",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "windows": false,
-      "npmPkg": "@aws-amplify/datastore",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/aws-amplify/amplify-js",
-          "clone": "https://github.com/aws-amplify/amplify-js.git",
-          "homepage": "https://aws-amplify.github.io/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T22:34:16Z",
-          "createdAt": "2017-10-02T22:17:14Z",
-          "pushedAt": "2020-05-11T22:37:53Z",
-          "forks": 1283,
-          "issues": 647,
-          "subscribers": 180,
-          "stars": 6841
-        },
-        "name": "@aws-amplify/datastore",
-        "fullName": "aws-amplify/amplify-js",
-        "description": "AppSyncLocal support for aws-amplify"
-      },
-      "npm": {
-        "downloads": 175794,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/aws-amplify/amplify-js/tree/master/packages/aws-amplify-react-native",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "windows": false,
-      "npmPkg": "aws-amplify-react-native",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/aws-amplify/amplify-js",
-          "clone": "https://github.com/aws-amplify/amplify-js.git"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T22:34:16Z",
-          "createdAt": "2017-10-02T22:17:14Z",
-          "pushedAt": "2020-05-11T22:37:53Z",
-          "forks": 1283,
-          "issues": 647,
-          "subscribers": 180,
-          "stars": 6841
-        },
-        "name": "aws-amplify-react-native",
-        "fullName": "aws-amplify/amplify-js",
-        "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications."
-      },
-      "npm": {
-        "downloads": 66927,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/aws-amplify/amplify-js/tree/master/packages/auth",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "windows": false,
-      "npmPkg": "@aws-amplify/auth",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/aws-amplify/amplify-js",
-          "clone": "https://github.com/aws-amplify/amplify-js.git",
-          "homepage": "https://aws-amplify.github.io/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T22:34:16Z",
-          "createdAt": "2017-10-02T22:17:14Z",
-          "pushedAt": "2020-05-11T22:37:53Z",
-          "forks": 1283,
-          "issues": 647,
-          "subscribers": 180,
-          "stars": 6841
-        },
-        "name": "@aws-amplify/auth",
-        "fullName": "aws-amplify/amplify-js",
-        "description": "Auth category of aws-amplify"
-      },
-      "npm": {
-        "downloads": 723620,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/aws-amplify/amplify-js/tree/master/packages/pushnotification",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "windows": false,
-      "npmPkg": "@aws-amplify/pushnotification",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/aws-amplify/amplify-js",
-          "clone": "https://github.com/aws-amplify/amplify-js.git",
-          "homepage": "https://aws-amplify.github.io/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T22:34:16Z",
-          "createdAt": "2017-10-02T22:17:14Z",
-          "pushedAt": "2020-05-11T22:37:53Z",
-          "forks": 1283,
-          "issues": 647,
-          "subscribers": 180,
-          "stars": 6841
-        },
-        "name": "@aws-amplify/pushnotification",
-        "fullName": "aws-amplify/amplify-js",
-        "description": "Push notifications category of aws-amplify"
-      },
-      "npm": {
-        "downloads": 24417,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/react-native-picker",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "windows": false,
-      "unmaintained": false,
-      "npmPkg": "@react-native-community/picker",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/react-native-picker",
-          "clone": "https://github.com/react-native-community/react-native-picker.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-10T08:18:23Z",
-          "createdAt": "2019-03-01T01:55:16Z",
-          "pushedAt": "2020-05-11T22:28:56Z",
-          "forks": 33,
-          "issues": 21,
-          "subscribers": 4,
-          "stars": 104
-        },
-        "name": "react-native-picker",
-        "fullName": "react-native-community/react-native-picker",
-        "description": "Picker is a cross-platform UI component for selecting an item from a list of options.",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 28989,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/invertase/react-native-firebase",
-      "ios": true,
-      "android": true,
-      "expo": false,
-      "web": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/invertase/react-native-firebase",
-          "clone": "https://github.com/invertase/react-native-firebase.git",
-          "homepage": "https://rnfirebase.io"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T21:13:32Z",
-          "createdAt": "2017-02-01T12:01:03Z",
-          "pushedAt": "2020-05-11T21:48:17Z",
-          "forks": 1361,
-          "issues": 152,
-          "subscribers": 154,
-          "stars": 7366
-        },
-        "name": "react-native-firebase",
-        "fullName": "invertase/react-native-firebase",
-        "description": "🔥 A well-tested feature-rich modular Firebase implementation for React Native. Supports both iOS & Android platforms for all Firebase services.",
-        "topics": [
-          "analytics",
-          "android",
-          "auth",
-          "crashlytics",
-          "database",
-          "fcm",
-          "firebase",
-          "firestore",
-          "ios",
-          "javascript",
-          "push-notifications",
-          "react",
-          "react-hooks",
-          "react-native",
-          "react-native-app",
-          "realtime-database",
-          "remote-config",
-          "storage",
-          "transactions",
-          "web-sdk"
-        ],
-        "license": {
-          "key": "other",
-          "name": "Other",
-          "spdx_id": "NOASSERTION",
-          "url": null,
-          "node_id": "MDc6TGljZW5zZTA="
-        }
-      },
-      "npmPkg": "react-native-firebase",
-      "npm": {
-        "downloads": 271322,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " analytics android auth crashlytics database fcm firebase firestore ios javascript push-notifications react react-hooks react-native react-native-app realtime-database remote-config storage transactions web-sdk"
-    },
-    {
-      "githubUrl": "https://github.com/microsoft/react-native-windows",
-      "windows": true,
-      "npmPkg": "react-native-windows",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/microsoft/react-native-windows",
-          "clone": "https://github.com/microsoft/react-native-windows.git",
-          "homepage": "http://facebook.github.io/react-native/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T20:41:36Z",
-          "createdAt": "2015-12-15T00:16:54Z",
-          "pushedAt": "2020-05-11T21:19:16Z",
-          "forks": 885,
-          "issues": 435,
-          "subscribers": 307,
-          "stars": 11460
-        },
-        "name": "react-native-windows",
-        "fullName": "microsoft/react-native-windows",
-        "description": "A framework for building native Windows apps with React.",
-        "topics": [
-          "dotnet",
-          "react",
-          "react-native",
-          "uwp",
-          "xbox"
-        ],
-        "license": {
-          "key": "other",
-          "name": "Other",
-          "spdx_id": "NOASSERTION",
-          "url": null,
-          "node_id": "MDc6TGljZW5zZTA="
-        }
-      },
-      "npm": {
-        "downloads": 54224,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " dotnet react react-native uwp xbox"
     },
     {
       "githubUrl": "https://github.com/wKovacs64/react-native-responsive-image-view",
@@ -4415,9 +6450,9 @@
         }
       },
       "npm": {
-        "downloads": 178,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 179,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -4425,68 +6460,6 @@
         "Recently updated"
       ],
       "topicSearchString": " image react react-native react-native-component responsive-images view"
-    },
-    {
-      "githubUrl": "https://github.com/davodesign84/react-native-mixpanel",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/davodesign84/react-native-mixpanel",
-          "clone": "https://github.com/davodesign84/react-native-mixpanel.git",
-          "homepage": null
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-06T08:52:39Z",
-          "createdAt": "2015-11-11T00:10:10Z",
-          "pushedAt": "2020-05-11T21:11:13Z",
-          "forks": 192,
-          "issues": 59,
-          "subscribers": 14,
-          "stars": 411
-        },
-        "name": "react-native-mixpanel",
-        "fullName": "davodesign84/react-native-mixpanel",
-        "description": "A React Native wrapper for Mixpanel tracking",
-        "topics": [
-          "android",
-          "ios-app",
-          "java",
-          "mixpanel-ios-sdk",
-          "mixpanel-sdk",
-          "mobile-app",
-          "notifications",
-          "react-native",
-          "xcode"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-mixpanel",
-      "npm": {
-        "downloads": 74867,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 63,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " android ios-app java mixpanel-ios-sdk mixpanel-sdk mobile-app notifications react-native xcode"
     },
     {
       "githubUrl": "https://github.com/seniv/react-native-notifier",
@@ -4539,9 +6512,9 @@
         }
       },
       "npm": {
-        "downloads": 208,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 217,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -4570,13 +6543,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T20:58:27Z",
+          "updatedAt": "2020-05-12T08:02:26Z",
           "createdAt": "2019-08-14T18:26:28Z",
           "pushedAt": "2020-05-11T20:58:24Z",
           "forks": 36,
-          "issues": 12,
+          "issues": 14,
           "subscribers": 7,
-          "stars": 440
+          "stars": 441
         },
         "name": "react-native-safe-area-context",
         "fullName": "th3rdwave/react-native-safe-area-context",
@@ -4599,9 +6572,9 @@
       },
       "npmPkg": "react-native-safe-area-context",
       "npm": {
-        "downloads": 586964,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 607601,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -4628,13 +6601,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T22:06:34Z",
+          "updatedAt": "2020-05-12T14:13:42Z",
           "createdAt": "2016-09-08T14:21:41Z",
           "pushedAt": "2020-05-11T20:33:52Z",
-          "forks": 3715,
-          "issues": 109,
-          "subscribers": 385,
-          "stars": 18591
+          "forks": 3717,
+          "issues": 110,
+          "subscribers": 384,
+          "stars": 18598
         },
         "name": "react-native-elements",
         "fullName": "react-native-elements/react-native-elements",
@@ -4655,9 +6628,9 @@
       },
       "npmPkg": "react-native-elements",
       "npm": {
-        "downloads": 311130,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 319799,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -4714,9 +6687,9 @@
         }
       },
       "npm": {
-        "downloads": 21063,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 22051,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -4745,13 +6718,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T11:23:23Z",
+          "updatedAt": "2020-05-12T14:14:40Z",
           "createdAt": "2015-10-30T08:42:28Z",
           "pushedAt": "2020-05-11T20:10:12Z",
           "forks": 378,
           "issues": 79,
-          "subscribers": 50,
-          "stars": 1995
+          "subscribers": 49,
+          "stars": 1997
         },
         "name": "react-native-sqlite-storage",
         "fullName": "andpor/react-native-sqlite-storage",
@@ -4766,9 +6739,9 @@
         }
       },
       "npm": {
-        "downloads": 45551,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 47492,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -4778,67 +6751,6 @@
         "Recently updated"
       ],
       "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/react-native-kit/react-native-track-player",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-kit/react-native-track-player",
-          "clone": "https://github.com/react-native-kit/react-native-track-player.git",
-          "homepage": "https://react-native-track-player.js.org/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T14:11:19Z",
-          "createdAt": "2017-03-16T20:18:39Z",
-          "pushedAt": "2020-05-11T19:28:44Z",
-          "forks": 409,
-          "issues": 206,
-          "subscribers": 47,
-          "stars": 1311
-        },
-        "name": "react-native-track-player",
-        "fullName": "react-native-kit/react-native-track-player",
-        "description": "A fully fledged audio module created for music apps. Provides audio playback, external media controls, chromecast support, background mode and more!",
-        "topics": [
-          "android",
-          "ios",
-          "media-control",
-          "music-library",
-          "music-player",
-          "react-native",
-          "windows"
-        ],
-        "license": {
-          "key": "apache-2.0",
-          "name": "Apache License 2.0",
-          "spdx_id": "Apache-2.0",
-          "url": "https://api.github.com/licenses/apache-2.0",
-          "node_id": "MDc6TGljZW5zZTI="
-        }
-      },
-      "npmPkg": "react-native-track-player",
-      "npm": {
-        "downloads": 15477,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 50,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " android ios media-control music-library music-player react-native windows"
     },
     {
       "githubUrl": "https://github.com/souvik-ghosh/react-native-create-thumbnail",
@@ -4861,7 +6773,7 @@
           "updatedAt": "2020-05-11T19:10:40Z",
           "createdAt": "2019-12-08T14:43:48Z",
           "pushedAt": "2020-05-11T19:20:22Z",
-          "forks": 5,
+          "forks": 4,
           "issues": 3,
           "subscribers": 1,
           "stars": 16
@@ -4886,9 +6798,9 @@
       },
       "npmPkg": "react-native-create-thumbnail",
       "npm": {
-        "downloads": 2003,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2078,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -4914,13 +6826,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T22:32:18Z",
+          "updatedAt": "2020-05-12T16:30:02Z",
           "createdAt": "2015-03-31T05:08:38Z",
           "pushedAt": "2020-05-11T19:14:39Z",
-          "forks": 1748,
+          "forks": 1747,
           "issues": 792,
           "subscribers": 96,
-          "stars": 4916
+          "stars": 4917
         },
         "name": "react-native-video",
         "fullName": "react-native-community/react-native-video",
@@ -4936,9 +6848,9 @@
       },
       "npmPkg": "react-native-video",
       "npm": {
-        "downloads": 232584,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 240510,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -4987,9 +6899,9 @@
       },
       "npmPkg": "react-native-search-bar",
       "npm": {
-        "downloads": 7073,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7314,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -5019,13 +6931,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T16:32:06Z",
+          "updatedAt": "2020-05-12T16:02:13Z",
           "createdAt": "2015-04-20T15:22:55Z",
           "pushedAt": "2020-05-11T17:21:16Z",
-          "forks": 2119,
+          "forks": 2120,
           "issues": 661,
-          "subscribers": 163,
-          "stars": 8817
+          "subscribers": 165,
+          "stars": 8822
         },
         "name": "react-native-swiper",
         "fullName": "leecade/react-native-swiper",
@@ -5045,9 +6957,9 @@
       },
       "npmPkg": "react-native-swiper",
       "npm": {
-        "downloads": 201468,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 208371,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -5058,184 +6970,6 @@
         "Recently updated"
       ],
       "topicSearchString": " react react-native swipe"
-    },
-    {
-      "githubUrl": "https://github.com/underscopeio/react-native-navigation-hooks",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "windows": false,
-      "npmPkg": "react-native-navigation-hooks",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/underscopeio/react-native-navigation-hooks",
-          "clone": "https://github.com/underscopeio/react-native-navigation-hooks.git",
-          "homepage": null
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T00:43:38Z",
-          "createdAt": "2019-06-10T00:29:58Z",
-          "pushedAt": "2020-05-11T17:21:05Z",
-          "forks": 9,
-          "issues": 1,
-          "subscribers": 8,
-          "stars": 112
-        },
-        "name": "react-native-navigation-hooks",
-        "fullName": "underscopeio/react-native-navigation-hooks",
-        "description": "A set of React hooks for React Native Navigation.",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 5426,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/react-native-tab-view",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": true,
-      "goldstar": true,
-      "examples": [
-        "https://snack.expo.io/HJjbO4nSW",
-        "https://expo.io/@satya164/react-native-tab-view-demos"
-      ],
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/react-native-tab-view",
-          "clone": "https://github.com/react-native-community/react-native-tab-view.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T16:12:42Z",
-          "createdAt": "2016-06-15T21:38:19Z",
-          "pushedAt": "2020-05-11T17:15:09Z",
-          "forks": 811,
-          "issues": 28,
-          "subscribers": 52,
-          "stars": 3848
-        },
-        "name": "react-native-tab-view",
-        "fullName": "react-native-community/react-native-tab-view",
-        "description": "A cross-platform Tab View component for React Native",
-        "topics": [
-          "pager-component",
-          "react-native",
-          "swipe",
-          "swipeview",
-          "tabbar",
-          "tabs"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-tab-view",
-      "npm": {
-        "downloads": 1107897,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 100,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recommended",
-        "Recently updated"
-      ],
-      "topicSearchString": " pager-component react-native swipe swipeview tabbar tabs"
-    },
-    {
-      "githubUrl": "https://github.com/software-mansion/react-native-reanimated",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/software-mansion/react-native-reanimated",
-          "clone": "https://github.com/software-mansion/react-native-reanimated.git",
-          "homepage": "https://software-mansion.github.io/react-native-reanimated"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T18:25:40Z",
-          "createdAt": "2018-04-25T06:35:29Z",
-          "pushedAt": "2020-05-11T16:59:55Z",
-          "forks": 342,
-          "issues": 134,
-          "subscribers": 39,
-          "stars": 2849
-        },
-        "name": "react-native-reanimated",
-        "fullName": "software-mansion/react-native-reanimated",
-        "description": "React Native's Animated library reimplemented",
-        "topics": [
-          "animation",
-          "gesture",
-          "javascript",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-reanimated",
-      "npm": {
-        "downloads": 949908,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " animation gesture javascript react-native"
     },
     {
       "githubUrl": "https://github.com/itinance/react-native-fs",
@@ -5255,13 +6989,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T20:41:28Z",
+          "updatedAt": "2020-05-12T08:56:46Z",
           "createdAt": "2015-05-08T17:04:15Z",
           "pushedAt": "2020-05-11T16:57:12Z",
-          "forks": 688,
-          "issues": 378,
+          "forks": 689,
+          "issues": 379,
           "subscribers": 48,
-          "stars": 3535
+          "stars": 3537
         },
         "name": "react-native-fs",
         "fullName": "itinance/react-native-fs",
@@ -5281,9 +7015,9 @@
       },
       "npmPkg": "react-native-fs",
       "npm": {
-        "downloads": 266256,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 275550,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -5294,63 +7028,6 @@
         "Recently updated"
       ],
       "topicSearchString": " download filesystem react-native"
-    },
-    {
-      "githubUrl": "https://github.com/akveo/react-native-ui-kitten",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/akveo/react-native-ui-kitten",
-          "clone": "https://github.com/akveo/react-native-ui-kitten.git",
-          "homepage": "https://akveo.github.io/react-native-ui-kitten/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T22:28:17Z",
-          "createdAt": "2016-12-20T08:22:38Z",
-          "pushedAt": "2020-05-11T15:56:58Z",
-          "forks": 729,
-          "issues": 45,
-          "subscribers": 127,
-          "stars": 6428
-        },
-        "name": "react-native-ui-kitten",
-        "fullName": "akveo/react-native-ui-kitten",
-        "description": ":boom: React Native UI Library based on Eva Design System  :new_moon_with_face::sparkles:Dark Mode",
-        "topics": [
-          "react",
-          "react-native",
-          "ui-kit"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-ui-kitten",
-      "npm": {
-        "downloads": 5342,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " react react-native ui-kit"
     },
     {
       "githubUrl": "https://github.com/kirillzyusko/react-native-bundle-splitter",
@@ -5393,9 +7070,9 @@
       },
       "npmPkg": "react-native-bundle-splitter",
       "npm": {
-        "downloads": 3300,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3417,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -5439,9 +7116,9 @@
         ]
       },
       "npm": {
-        "downloads": 23099,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 24074,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -5451,182 +7128,6 @@
         "Recently updated"
       ],
       "topicSearchString": " animation dom declarative popmotion"
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/react-native-checkbox",
-      "ios": false,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "examples": [],
-      "npmPkg": "@react-native-community/checkbox",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/react-native-checkbox",
-          "clone": "https://github.com/react-native-community/react-native-checkbox.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-08T19:28:08Z",
-          "createdAt": "2019-02-06T17:44:24Z",
-          "pushedAt": "2020-05-11T14:12:15Z",
-          "forks": 15,
-          "issues": 7,
-          "subscribers": 4,
-          "stars": 77
-        },
-        "name": "react-native-checkbox",
-        "fullName": "react-native-community/react-native-checkbox",
-        "description": "Checkbox component for React Native",
-        "topics": [
-          "checkbox",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 14836,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": " checkbox react-native"
-    },
-    {
-      "githubUrl": "https://github.com/shoutem/ui",
-      "ios": true,
-      "android": true,
-      "expo": true,
-      "npmPkg": "@shoutem/ui",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/shoutem/ui",
-          "clone": "https://github.com/shoutem/ui.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T13:13:13Z",
-          "createdAt": "2016-08-08T15:26:08Z",
-          "pushedAt": "2020-05-11T13:16:06Z",
-          "forks": 526,
-          "issues": 105,
-          "subscribers": 110,
-          "stars": 4547
-        },
-        "name": "ui",
-        "fullName": "shoutem/ui",
-        "description": "Customizable set of components for React Native applications",
-        "topics": [
-          "android",
-          "ios",
-          "native-components",
-          "react-native",
-          "shoutem",
-          "shoutem-ui"
-        ],
-        "license": {
-          "key": "other",
-          "name": "Other",
-          "spdx_id": "NOASSERTION",
-          "url": null,
-          "node_id": "MDc6TGljZW5zZTA="
-        }
-      },
-      "npm": {
-        "downloads": 2025,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " android ios native-components react-native shoutem shoutem-ui"
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/react-native-camera",
-      "ios": true,
-      "android": true,
-      "expo": false,
-      "web": false,
-      "windows": false,
-      "npmPkg": "react-native-camera",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/react-native-camera",
-          "clone": "https://github.com/react-native-community/react-native-camera.git",
-          "homepage": "https://react-native-community.github.io/react-native-camera/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T20:49:28Z",
-          "createdAt": "2015-04-01T00:54:40Z",
-          "pushedAt": "2020-05-11T13:06:59Z",
-          "forks": 2717,
-          "issues": 110,
-          "subscribers": 195,
-          "stars": 8378
-        },
-        "name": "react-native-camera",
-        "fullName": "react-native-community/react-native-camera",
-        "description": "A Camera component for React Native. Also supports barcode scanning!",
-        "topics": [
-          "camera",
-          "face-detection",
-          "react-native",
-          "rncamera"
-        ],
-        "license": {
-          "key": "other",
-          "name": "Other",
-          "spdx_id": "NOASSERTION",
-          "url": null,
-          "node_id": "MDc6TGljZW5zZTA="
-        }
-      },
-      "npm": {
-        "downloads": 276456,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " camera face-detection react-native rncamera"
     },
     {
       "githubUrl": "https://github.com/Flipkart/recyclerlistview",
@@ -5653,13 +7154,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T17:32:45Z",
+          "updatedAt": "2020-05-12T10:17:02Z",
           "createdAt": "2017-04-16T06:14:33Z",
           "pushedAt": "2020-05-11T12:48:05Z",
           "forks": 227,
           "issues": 78,
           "subscribers": 59,
-          "stars": 2724
+          "stars": 2726
         },
         "name": "recyclerlistview",
         "fullName": "Flipkart/recyclerlistview",
@@ -5684,9 +7185,9 @@
         }
       },
       "npm": {
-        "downloads": 45485,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 47573,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -5715,13 +7216,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T22:14:02Z",
+          "updatedAt": "2020-05-12T18:10:18Z",
           "createdAt": "2017-06-14T19:50:59Z",
           "pushedAt": "2020-05-11T12:47:36Z",
-          "forks": 1627,
-          "issues": 594,
+          "forks": 1632,
+          "issues": 595,
           "subscribers": 208,
-          "stars": 21967
+          "stars": 21991
         },
         "name": "formik",
         "fullName": "jaredpalmer/formik",
@@ -5747,9 +7248,9 @@
       },
       "npmPkg": "formik",
       "npm": {
-        "downloads": 3253307,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3379377,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -5760,347 +7261,6 @@
         "Recently updated"
       ],
       "topicSearchString": " form formik forms higher-order-component hooks react react-hooks react-native render-props"
-    },
-    {
-      "githubUrl": "https://github.com/wix/react-native-navigation",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "goldstar": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/wix/react-native-navigation",
-          "clone": "https://github.com/wix/react-native-navigation.git",
-          "homepage": "https://wix.github.io/react-native-navigation/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T17:16:42Z",
-          "createdAt": "2016-03-11T11:22:54Z",
-          "pushedAt": "2020-05-11T12:41:14Z",
-          "forks": 2550,
-          "issues": 136,
-          "subscribers": 522,
-          "stars": 11448
-        },
-        "name": "react-native-navigation",
-        "fullName": "wix/react-native-navigation",
-        "description": "A complete native navigation solution for React Native",
-        "topics": [
-          "navigation",
-          "navigator",
-          "react-native",
-          "react-native-navigation"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-navigation",
-      "npm": {
-        "downloads": 119695,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recommended",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " navigation navigator react-native react-native-navigation"
-    },
-    {
-      "githubUrl": "https://github.com/netguru/sticky-parallax-header",
-      "examples": [
-        "https://github.com/netguru/sticky-parallax-header/tree/master/example"
-      ],
-      "npmPkg": "react-native-sticky-parallax-header",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": true,
-      "windows": false,
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/netguru/sticky-parallax-header",
-          "clone": "https://github.com/netguru/sticky-parallax-header.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T15:02:21Z",
-          "createdAt": "2019-04-30T07:18:03Z",
-          "pushedAt": "2020-05-11T12:00:19Z",
-          "forks": 39,
-          "issues": 10,
-          "subscribers": 14,
-          "stars": 284
-        },
-        "name": "sticky-parallax-header",
-        "fullName": "netguru/sticky-parallax-header",
-        "description": "A simple React Native library, enabling to create a fully custom header for your iOS and Android apps.",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 1006,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/async-storage",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "windows": true,
-      "unmaintained": false,
-      "npmPkg": "@react-native-community/async-storage",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/async-storage",
-          "clone": "https://github.com/react-native-community/async-storage.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T19:40:07Z",
-          "createdAt": "2019-02-06T15:51:20Z",
-          "pushedAt": "2020-05-11T10:53:31Z",
-          "forks": 229,
-          "issues": 25,
-          "subscribers": 23,
-          "stars": 1632
-        },
-        "name": "async-storage",
-        "fullName": "react-native-community/async-storage",
-        "description": "An asynchronous, persistent, key-value storage system for React Native.",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 869154,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/react-native-viewpager",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "windows": false,
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/react-native-viewpager",
-          "clone": "https://github.com/react-native-community/react-native-viewpager.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T09:34:57Z",
-          "createdAt": "2019-02-06T16:17:45Z",
-          "pushedAt": "2020-05-11T09:34:54Z",
-          "forks": 108,
-          "issues": 37,
-          "subscribers": 16,
-          "stars": 568
-        },
-        "name": "react-native-viewpager",
-        "fullName": "react-native-community/react-native-viewpager",
-        "description": "React Native wrapper for the Android ViewPager and iOS UIPageViewController.",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-viewpager",
-      "npm": {
-        "downloads": 4808,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/Nozbe/WatermelonDB",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": false,
-      "npmPkg": "@nozbe/watermelondb",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/Nozbe/WatermelonDB",
-          "clone": "https://github.com/Nozbe/WatermelonDB.git",
-          "homepage": "https://nozbe.github.io/WatermelonDB/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T20:35:36Z",
-          "createdAt": "2018-08-28T15:32:05Z",
-          "pushedAt": "2020-05-11T09:04:02Z",
-          "forks": 314,
-          "issues": 72,
-          "subscribers": 111,
-          "stars": 6607
-        },
-        "name": "WatermelonDB",
-        "fullName": "Nozbe/WatermelonDB",
-        "description": "🍉 Reactive & asynchronous database for powerful React and React Native apps ⚡️",
-        "topics": [
-          "database",
-          "persistence",
-          "react",
-          "react-native",
-          "reactive",
-          "rxjs"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 5844,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " database persistence react react-native reactive rxjs"
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/react-native-webview",
-      "ios": true,
-      "android": true,
-      "expo": true,
-      "web": false,
-      "windows": true,
-      "macos": true,
-      "npmPkg": "react-native-webview",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/react-native-webview",
-          "clone": "https://github.com/react-native-community/react-native-webview.git",
-          "homepage": "https://github.com/react-native-community/discussions-and-proposals/pull/3"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T08:36:10Z",
-          "createdAt": "2018-09-09T00:14:44Z",
-          "pushedAt": "2020-05-11T08:31:58Z",
-          "forks": 1202,
-          "issues": 141,
-          "subscribers": 36,
-          "stars": 2554
-        },
-        "name": "react-native-webview",
-        "fullName": "react-native-community/react-native-webview",
-        "description": "React Native Cross-Platform WebView",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 738199,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": ""
     },
     {
       "githubUrl": "https://github.com/callstack/react-native-paper",
@@ -6120,13 +7280,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T20:38:06Z",
+          "updatedAt": "2020-05-12T17:27:00Z",
           "createdAt": "2016-10-19T05:56:53Z",
           "pushedAt": "2020-05-11T08:14:29Z",
-          "forks": 813,
-          "issues": 111,
+          "forks": 811,
+          "issues": 109,
           "subscribers": 93,
-          "stars": 5764
+          "stars": 5771
         },
         "name": "react-native-paper",
         "fullName": "callstack/react-native-paper",
@@ -6146,9 +7306,9 @@
       },
       "npmPkg": "react-native-paper",
       "npm": {
-        "downloads": 157937,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 162284,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -6207,9 +7367,9 @@
         }
       },
       "npm": {
-        "downloads": 640725,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 665063,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -6261,9 +7421,9 @@
       },
       "npmPkg": "react-native-safe-area-view",
       "npm": {
-        "downloads": 1122921,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1156794,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -6273,65 +7433,6 @@
         "Recently updated"
       ],
       "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/Purii/react-native-tableview-simple",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/Purii/react-native-tableview-simple",
-          "clone": "https://github.com/Purii/react-native-tableview-simple.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-03T09:07:14Z",
-          "createdAt": "2015-10-25T21:05:29Z",
-          "pushedAt": "2020-05-11T04:52:09Z",
-          "forks": 58,
-          "issues": 8,
-          "subscribers": 11,
-          "stars": 321
-        },
-        "name": "react-native-tableview-simple",
-        "fullName": "Purii/react-native-tableview-simple",
-        "description": "Flexible and lightweight React Native component for UITableView made with pure CSS",
-        "topics": [
-          "css",
-          "ios",
-          "javascript",
-          "react",
-          "react-native",
-          "tableview",
-          "uitableview"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-tableview-simple",
-      "npm": {
-        "downloads": 3751,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": " css ios javascript react react-native tableview uitableview"
     },
     {
       "githubUrl": "https://github.com/appintheair/react-native-looped-carousel",
@@ -6376,9 +7477,9 @@
       },
       "npmPkg": "react-native-looped-carousel",
       "npm": {
-        "downloads": 6239,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6630,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -6388,62 +7489,6 @@
         "Recently updated"
       ],
       "topicSearchString": " carousel react react-native"
-    },
-    {
-      "githubUrl": "https://github.com/dooboolab/react-native-iap",
-      "ios": true,
-      "android": true,
-      "npmPkg": "react-native-iap",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/dooboolab/react-native-iap",
-          "clone": "https://github.com/dooboolab/react-native-iap.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T18:50:03Z",
-          "createdAt": "2017-10-22T00:31:20Z",
-          "pushedAt": "2020-05-11T01:55:51Z",
-          "forks": 292,
-          "issues": 55,
-          "subscribers": 24,
-          "stars": 1346
-        },
-        "name": "react-native-iap",
-        "fullName": "dooboolab/react-native-iap",
-        "description": "react-native native module for In App Purchase.",
-        "topics": [
-          "in-app-purchase",
-          "java",
-          "objective-c",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 48409,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 63,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " in-app-purchase java objective-c react-native"
     },
     {
       "githubUrl": "https://github.com/EstebanFuentealba/react-native-share",
@@ -6492,9 +7537,9 @@
       },
       "npmPkg": "react-native-share",
       "npm": {
-        "downloads": 185156,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 192563,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -6523,13 +7568,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T21:18:30Z",
+          "updatedAt": "2020-05-12T04:36:52Z",
           "createdAt": "2015-06-11T05:01:07Z",
           "pushedAt": "2020-05-11T00:00:25Z",
           "forks": 1946,
           "issues": 101,
           "subscribers": 148,
-          "stars": 6470
+          "stars": 6471
         },
         "name": "react-native-scrollable-tab-view",
         "fullName": "ptomasroos/react-native-scrollable-tab-view",
@@ -6544,9 +7589,9 @@
       },
       "npmPkg": "react-native-scrollable-tab-view",
       "npm": {
-        "downloads": 55495,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 57577,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -6598,9 +7643,9 @@
         }
       },
       "npm": {
-        "downloads": 2436,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2549,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -6626,13 +7671,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:00:03Z",
+          "updatedAt": "2020-05-12T17:05:49Z",
           "createdAt": "2016-10-11T07:22:24Z",
           "pushedAt": "2020-05-10T17:27:24Z",
-          "forks": 1372,
-          "issues": 155,
-          "subscribers": 101,
-          "stars": 7124
+          "forks": 1373,
+          "issues": 156,
+          "subscribers": 102,
+          "stars": 7129
         },
         "name": "react-native-snap-carousel",
         "fullName": "archriss/react-native-snap-carousel",
@@ -6655,9 +7700,9 @@
       },
       "npmPkg": "react-native-snap-carousel",
       "npm": {
-        "downloads": 300318,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 310992,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -6709,9 +7754,9 @@
       },
       "npmPkg": "react-navigation-header-buttons",
       "npm": {
-        "downloads": 24464,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 25478,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -6764,9 +7809,9 @@
         }
       },
       "npm": {
-        "downloads": 246,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 249,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -6793,13 +7838,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-06T18:18:18Z",
+          "updatedAt": "2020-05-12T11:32:52Z",
           "createdAt": "2016-03-01T14:11:31Z",
           "pushedAt": "2020-05-10T12:23:20Z",
-          "forks": 233,
+          "forks": 234,
           "issues": 70,
-          "subscribers": 15,
-          "stars": 1088
+          "subscribers": 14,
+          "stars": 1089
         },
         "name": "react-native-actionsheet",
         "fullName": "beefe/react-native-actionsheet",
@@ -6818,9 +7863,9 @@
       },
       "npmPkg": "react-native-actionsheet",
       "npm": {
-        "downloads": 90959,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 94454,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -6878,9 +7923,9 @@
         }
       },
       "npm": {
-        "downloads": 341532,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 345195,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -6890,71 +7935,6 @@
         "Recently updated"
       ],
       "topicSearchString": " javascript javascript-sdk parse parse-js parse-platform"
-    },
-    {
-      "githubUrl": "https://github.com/getsentry/sentry-react-native",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": true,
-      "windows": false,
-      "npmPkg": "@sentry/react-native",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/getsentry/sentry-react-native",
-          "clone": "https://github.com/getsentry/sentry-react-native.git",
-          "homepage": "https://sentry.io"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T17:02:58Z",
-          "createdAt": "2016-11-30T14:45:57Z",
-          "pushedAt": "2020-05-10T06:30:48Z",
-          "forks": 205,
-          "issues": 61,
-          "subscribers": 48,
-          "stars": 833
-        },
-        "name": "sentry-react-native",
-        "fullName": "getsentry/sentry-react-native",
-        "description": "Official Sentry SDK for react-native",
-        "topics": [
-          "android",
-          "crash",
-          "ios",
-          "javascript",
-          "mixed-stacktraces",
-          "raven-js",
-          "react",
-          "react-native",
-          "sdk",
-          "sentry"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 315248,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 63,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " android crash ios javascript mixed-stacktraces raven-js react react-native sdk sentry"
     },
     {
       "githubUrl": "https://github.com/react-native-community/segmented-control",
@@ -6976,13 +7956,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T10:18:38Z",
+          "updatedAt": "2020-05-12T15:41:18Z",
           "createdAt": "2019-02-06T17:47:06Z",
           "pushedAt": "2020-05-10T04:46:11Z",
           "forks": 15,
           "issues": 4,
           "subscribers": 5,
-          "stars": 65
+          "stars": 66
         },
         "name": "segmented-control",
         "fullName": "react-native-community/segmented-control",
@@ -7000,9 +7980,9 @@
         }
       },
       "npm": {
-        "downloads": 8192,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8643,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -7010,63 +7990,6 @@
         "Recently updated"
       ],
       "topicSearchString": " react-native segmented-control"
-    },
-    {
-      "githubUrl": "https://github.com/ascoders/react-native-image-viewer",
-      "ios": true,
-      "android": true,
-      "expo": true,
-      "npmPkg": "react-native-image-zoom-viewer",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/ascoders/react-native-image-viewer",
-          "clone": "https://github.com/ascoders/react-native-image-viewer.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T20:26:09Z",
-          "createdAt": "2016-09-13T13:43:44Z",
-          "pushedAt": "2020-05-10T02:50:32Z",
-          "forks": 408,
-          "issues": 124,
-          "subscribers": 21,
-          "stars": 1813
-        },
-        "name": "react-native-image-viewer",
-        "fullName": "ascoders/react-native-image-viewer",
-        "description": "🚀 tiny & fast lib for react native image viewer pan and zoom",
-        "topics": [
-          "image-viewer",
-          "react-component",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 82328,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 50,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " image-viewer react-component react-native"
     },
     {
       "githubUrl": "https://github.com/ivpusic/react-native-image-crop-picker",
@@ -7086,13 +8009,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T20:37:54Z",
+          "updatedAt": "2020-05-12T13:39:39Z",
           "createdAt": "2016-05-17T14:25:03Z",
           "pushedAt": "2020-05-09T22:44:36Z",
           "forks": 1005,
           "issues": 357,
           "subscribers": 69,
-          "stars": 4211
+          "stars": 4218
         },
         "name": "react-native-image-crop-picker",
         "fullName": "ivpusic/react-native-image-crop-picker",
@@ -7118,9 +8041,9 @@
       },
       "npmPkg": "react-native-image-crop-picker",
       "npm": {
-        "downloads": 179559,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 186078,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -7174,9 +8097,9 @@
         }
       },
       "npm": {
-        "downloads": 118,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 122,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -7232,9 +8155,9 @@
       },
       "npmPkg": "react-native-maps-directions",
       "npm": {
-        "downloads": 14281,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14826,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -7300,9 +8223,9 @@
         }
       },
       "npm": {
-        "downloads": 801,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 808,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -7332,13 +8255,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-10T09:24:50Z",
+          "updatedAt": "2020-05-12T00:58:23Z",
           "createdAt": "2015-06-30T10:23:38Z",
           "pushedAt": "2020-05-09T17:38:13Z",
           "forks": 399,
           "issues": 68,
-          "subscribers": 25,
-          "stars": 939
+          "subscribers": 24,
+          "stars": 940
         },
         "name": "react-native-youtube",
         "fullName": "davidohayon669/react-native-youtube",
@@ -7353,9 +8276,9 @@
         }
       },
       "npm": {
-        "downloads": 43268,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 44037,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -7364,117 +8287,6 @@
         "Recently updated"
       ],
       "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/FortAwesome/react-native-fontawesome",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": true,
-      "windows": false,
-      "npmPkg": "@fortawesome/react-native-fontawesome",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/FortAwesome/react-native-fontawesome",
-          "clone": "https://github.com/FortAwesome/react-native-fontawesome.git",
-          "homepage": null
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-10T00:17:36Z",
-          "createdAt": "2018-10-02T20:16:03Z",
-          "pushedAt": "2020-05-09T17:37:12Z",
-          "forks": 21,
-          "issues": 13,
-          "subscribers": 7,
-          "stars": 149
-        },
-        "name": "react-native-fontawesome",
-        "fullName": "FortAwesome/react-native-fontawesome",
-        "description": "Official React Native component for Font Awesome 5",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 22017,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/BugiDev/react-native-calendar-strip",
-      "ios": true,
-      "android": true,
-      "expo": true,
-      "examples": [
-        "https://snack.expo.io/By-aQF8LZ"
-      ],
-      "github": {
-        "urls": {
-          "repo": "https://github.com/BugiDev/react-native-calendar-strip",
-          "clone": "https://github.com/BugiDev/react-native-calendar-strip.git",
-          "homepage": null
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T18:28:33Z",
-          "createdAt": "2016-08-29T15:04:01Z",
-          "pushedAt": "2020-05-09T17:11:03Z",
-          "forks": 153,
-          "issues": 32,
-          "subscribers": 13,
-          "stars": 452
-        },
-        "name": "react-native-calendar-strip",
-        "fullName": "BugiDev/react-native-calendar-strip",
-        "description": "Easy to use and visually stunning calendar component for React Native.",
-        "topics": [
-          "calendar",
-          "calendar-strip",
-          "javascript",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-calendar-strip",
-      "npm": {
-        "downloads": 6370,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": " calendar calendar-strip javascript react-native"
     },
     {
       "githubUrl": "https://github.com/react-native-webrtc/react-native-webrtc",
@@ -7497,13 +8309,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:12:27Z",
+          "updatedAt": "2020-05-12T15:28:22Z",
           "createdAt": "2015-09-27T10:57:30Z",
           "pushedAt": "2020-05-09T17:02:09Z",
-          "forks": 660,
+          "forks": 661,
           "issues": 70,
           "subscribers": 108,
-          "stars": 2670
+          "stars": 2672
         },
         "name": "react-native-webrtc",
         "fullName": "react-native-webrtc/react-native-webrtc",
@@ -7522,9 +8334,9 @@
         }
       },
       "npm": {
-        "downloads": 25502,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 25918,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -7534,72 +8346,6 @@
         "Recently updated"
       ],
       "topicSearchString": " react react-native webrtc"
-    },
-    {
-      "githubUrl": "https://github.com/react-native-webrtc/react-native-callkeep",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "windows": false,
-      "examples": [
-        "https://github.com/wazo-pbx/wazo-react-native-demo"
-      ],
-      "unmaintained": false,
-      "npmPkg": "react-native-callkeep",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-webrtc/react-native-callkeep",
-          "clone": "https://github.com/react-native-webrtc/react-native-callkeep.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-09T23:24:44Z",
-          "createdAt": "2018-12-07T14:33:26Z",
-          "pushedAt": "2020-05-09T14:58:17Z",
-          "forks": 106,
-          "issues": 44,
-          "subscribers": 15,
-          "stars": 242
-        },
-        "name": "react-native-callkeep",
-        "fullName": "react-native-webrtc/react-native-callkeep",
-        "description": "iOS CallKit framework and Android ConnectionService for React Native",
-        "topics": [
-          "android",
-          "call-kit",
-          "callkit",
-          "connection-service",
-          "connectionservice",
-          "ios",
-          "react-native",
-          "voip",
-          "webrtc"
-        ],
-        "license": {
-          "key": "isc",
-          "name": "ISC License",
-          "spdx_id": "ISC",
-          "url": "https://api.github.com/licenses/isc",
-          "node_id": "MDc6TGljZW5zZTEw"
-        }
-      },
-      "npm": {
-        "downloads": 5020,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": " android call-kit callkit connection-service connectionservice ios react-native voip webrtc"
     },
     {
       "githubUrl": "https://github.com/zo0r/react-native-push-notification",
@@ -7619,13 +8365,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T19:42:21Z",
+          "updatedAt": "2020-05-12T13:23:52Z",
           "createdAt": "2015-12-14T19:53:36Z",
           "pushedAt": "2020-05-09T14:08:00Z",
-          "forks": 1448,
-          "issues": 692,
+          "forks": 1449,
+          "issues": 691,
           "subscribers": 100,
-          "stars": 4778
+          "stars": 4779
         },
         "name": "react-native-push-notification",
         "fullName": "zo0r/react-native-push-notification",
@@ -7645,9 +8391,9 @@
         }
       },
       "npm": {
-        "downloads": 138051,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 143239,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -7678,13 +8424,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T14:21:21Z",
+          "updatedAt": "2020-05-12T16:51:32Z",
           "createdAt": "2015-09-16T14:06:22Z",
           "pushedAt": "2020-05-09T13:06:24Z",
           "forks": 1130,
           "issues": 33,
           "subscribers": 75,
-          "stars": 4729
+          "stars": 4732
         },
         "name": "react-native-device-info",
         "fullName": "react-native-community/react-native-device-info",
@@ -7699,9 +8445,9 @@
         }
       },
       "npm": {
-        "downloads": 675209,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 701184,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -7759,9 +8505,9 @@
       },
       "npmPkg": "react-native-country-picker-modal",
       "npm": {
-        "downloads": 44183,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 45102,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -7813,9 +8559,9 @@
       },
       "npmPkg": "react-native-lightbox",
       "npm": {
-        "downloads": 91947,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 94554,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -7824,176 +8570,6 @@
         "Recently updated"
       ],
       "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/stephy/CalendarPicker",
-      "ios": true,
-      "android": true,
-      "expo": true,
-      "npmPkg": "react-native-calendar-picker",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/stephy/CalendarPicker",
-          "clone": "https://github.com/stephy/CalendarPicker.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T09:53:32Z",
-          "createdAt": "2015-04-12T06:11:27Z",
-          "pushedAt": "2020-05-09T03:11:55Z",
-          "forks": 231,
-          "issues": 15,
-          "subscribers": 12,
-          "stars": 488
-        },
-        "name": "CalendarPicker",
-        "fullName": "stephy/CalendarPicker",
-        "description": "CalendarPicker Component for React Native",
-        "topics": [
-          "calendar",
-          "calendar-picker-component",
-          "calendarpicker",
-          "react-native-calendar-picker",
-          "react-native-component"
-        ],
-        "license": null
-      },
-      "npm": {
-        "downloads": 8514,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 63,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " calendar calendar-picker-component calendarpicker react-native-calendar-picker react-native-component"
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/react-native-cameraroll",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "windows": false,
-      "unmaintained": false,
-      "npmPkg": "@react-native-community/cameraroll",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/react-native-cameraroll",
-          "clone": "https://github.com/react-native-community/react-native-cameraroll.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T08:00:29Z",
-          "createdAt": "2019-02-07T10:52:08Z",
-          "pushedAt": "2020-05-08T22:39:59Z",
-          "forks": 126,
-          "issues": 35,
-          "subscribers": 8,
-          "stars": 204
-        },
-        "name": "react-native-cameraroll",
-        "fullName": "react-native-community/react-native-cameraroll",
-        "description": "CameraRoll is a react-native native module that provides access to the local camera roll or photo library.",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 108170,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 63,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/wix/react-native-calendars",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "goldstar": true,
-      "examples": [
-        "https://snack.expo.io/HkoXUdhr-"
-      ],
-      "github": {
-        "urls": {
-          "repo": "https://github.com/wix/react-native-calendars",
-          "clone": "https://github.com/wix/react-native-calendars.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T17:03:38Z",
-          "createdAt": "2016-11-11T12:17:27Z",
-          "pushedAt": "2020-05-08T18:00:34Z",
-          "forks": 1664,
-          "issues": 443,
-          "subscribers": 357,
-          "stars": 5486
-        },
-        "name": "react-native-calendars",
-        "fullName": "wix/react-native-calendars",
-        "description": "React Native Calendar Components 🗓️ 📆 ",
-        "topics": [
-          "android",
-          "calendar",
-          "ios",
-          "react-native",
-          "ui-components"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-calendars",
-      "npm": {
-        "downloads": 136655,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recommended",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " android calendar ios react-native ui-components"
     },
     {
       "githubUrl": "https://github.com/unimodules/react-native-unimodules",
@@ -8017,9 +8593,9 @@
           "updatedAt": "2020-05-11T11:24:54Z",
           "createdAt": "2019-02-05T19:44:21Z",
           "pushedAt": "2020-05-08T13:26:26Z",
-          "forks": 43,
-          "issues": 44,
-          "subscribers": 15,
+          "forks": 44,
+          "issues": 45,
+          "subscribers": 14,
           "stars": 400
         },
         "name": "react-native-unimodules",
@@ -8035,9 +8611,9 @@
         }
       },
       "npm": {
-        "downloads": 151103,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 156936,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -8095,9 +8671,9 @@
       },
       "npmPkg": "react-native-modal-datetime-picker",
       "npm": {
-        "downloads": 238183,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 247083,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -8147,9 +8723,9 @@
         }
       },
       "npm": {
-        "downloads": 107322,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 111468,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -8210,9 +8786,9 @@
         }
       },
       "npm": {
-        "downloads": 709,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 695,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -8220,129 +8796,6 @@
         "Recently updated"
       ],
       "topicSearchString": " layout react react-native stacks typescript view"
-    },
-    {
-      "githubUrl": "https://github.com/wmcmahan/react-native-calendar-events",
-      "ios": true,
-      "android": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/wmcmahan/react-native-calendar-events",
-          "clone": "https://github.com/wmcmahan/react-native-calendar-events.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-08T09:49:25Z",
-          "createdAt": "2016-02-24T04:23:38Z",
-          "pushedAt": "2020-05-08T09:29:23Z",
-          "forks": 188,
-          "issues": 52,
-          "subscribers": 13,
-          "stars": 597
-        },
-        "name": "react-native-calendar-events",
-        "fullName": "wmcmahan/react-native-calendar-events",
-        "description": "📆 React Native Module for iOS and Android Calendar Events",
-        "topics": [
-          "alarms",
-          "andriod",
-          "andriod-sdk",
-          "android-calendar",
-          "android-calendar-api",
-          "android-calendar-events",
-          "calendar-api",
-          "calendar-events",
-          "ios-calendar",
-          "ios-calendar-api",
-          "ios-calendar-events",
-          "ios-library",
-          "ios-sdk",
-          "react-native",
-          "react-native-module",
-          "recurring-events"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-calendar-events",
-      "npm": {
-        "downloads": 22670,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 63,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " alarms andriod andriod-sdk android-calendar android-calendar-api android-calendar-events calendar-api calendar-events ios-calendar ios-calendar-api ios-calendar-events ios-library ios-sdk react-native react-native-module recurring-events"
-    },
-    {
-      "githubUrl": "https://github.com/software-mansion/react-native-screens",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "windows": false,
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/software-mansion/react-native-screens",
-          "clone": "https://github.com/software-mansion/react-native-screens.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T17:35:45Z",
-          "createdAt": "2018-08-03T11:36:32Z",
-          "pushedAt": "2020-05-08T08:59:50Z",
-          "forks": 179,
-          "issues": 119,
-          "subscribers": 29,
-          "stars": 1342
-        },
-        "name": "react-native-screens",
-        "fullName": "software-mansion/react-native-screens",
-        "description": "Native navigation primitives for your React Native app.",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-screens",
-      "npm": {
-        "downloads": 1234532,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 75,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": ""
     },
     {
       "githubUrl": "https://github.com/innoveit/react-native-ble-manager",
@@ -8360,13 +8813,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T00:32:42Z",
+          "updatedAt": "2020-05-12T12:45:01Z",
           "createdAt": "2016-05-20T09:20:14Z",
           "pushedAt": "2020-05-08T08:41:29Z",
           "forks": 427,
           "issues": 45,
-          "subscribers": 32,
-          "stars": 996
+          "subscribers": 33,
+          "stars": 1000
         },
         "name": "react-native-ble-manager",
         "fullName": "innoveit/react-native-ble-manager",
@@ -8388,9 +8841,9 @@
       },
       "npmPkg": "react-native-ble-manager",
       "npm": {
-        "downloads": 14464,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14854,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -8399,68 +8852,6 @@
         "Recently updated"
       ],
       "topicSearchString": " android ble bluetooth-low-energy ios react-native"
-    },
-    {
-      "githubUrl": "https://github.com/airbnb/react-native-maps",
-      "ios": true,
-      "android": true,
-      "expo": true,
-      "examples": [
-        "https://snack.expo.io/H1zOFxnN-"
-      ],
-      "goldstar": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/react-native-maps",
-          "clone": "https://github.com/react-native-community/react-native-maps.git",
-          "homepage": null
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T21:28:17Z",
-          "createdAt": "2015-12-29T19:54:20Z",
-          "pushedAt": "2020-05-08T06:46:48Z",
-          "forks": 3715,
-          "issues": 347,
-          "subscribers": 248,
-          "stars": 11023
-        },
-        "name": "react-native-maps",
-        "fullName": "react-native-community/react-native-maps",
-        "description": "React Native Mapview component for iOS + Android",
-        "topics": [
-          "google-maps",
-          "maps",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-maps",
-      "npm": {
-        "downloads": 371166,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recommended",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " google-maps maps react-native"
     },
     {
       "githubUrl": "https://github.com/infinitered/reactotron",
@@ -8480,13 +8871,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T20:56:14Z",
+          "updatedAt": "2020-05-12T13:27:15Z",
           "createdAt": "2016-04-15T21:58:32Z",
           "pushedAt": "2020-05-08T06:01:36Z",
           "forks": 742,
           "issues": 82,
           "subscribers": 168,
-          "stars": 11908
+          "stars": 11912
         },
         "name": "reactotron",
         "fullName": "infinitered/reactotron",
@@ -8510,9 +8901,9 @@
         }
       },
       "npm": {
-        "downloads": 607,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 624,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -8542,13 +8933,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T19:56:29Z",
+          "updatedAt": "2020-05-12T17:59:50Z",
           "createdAt": "2015-06-08T20:25:31Z",
           "pushedAt": "2020-05-08T04:01:30Z",
-          "forks": 1584,
+          "forks": 1585,
           "issues": 111,
           "subscribers": 107,
-          "stars": 6284
+          "stars": 6285
         },
         "name": "react-native-image-picker",
         "fullName": "react-native-community/react-native-image-picker",
@@ -8568,9 +8959,9 @@
       },
       "npmPkg": "react-native-image-picker",
       "npm": {
-        "downloads": 324996,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 336782,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -8601,13 +8992,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T10:31:18Z",
+          "updatedAt": "2020-05-12T14:42:56Z",
           "createdAt": "2017-04-13T04:13:44Z",
           "pushedAt": "2020-05-07T23:06:44Z",
-          "forks": 816,
+          "forks": 818,
           "issues": 254,
           "subscribers": 53,
-          "stars": 4669
+          "stars": 4672
         },
         "name": "react-native-fast-image",
         "fullName": "DylanVann/react-native-fast-image",
@@ -8630,9 +9021,9 @@
         }
       },
       "npm": {
-        "downloads": 270413,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 280321,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -8662,13 +9053,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T18:15:33Z",
+          "updatedAt": "2020-05-12T14:31:20Z",
           "createdAt": "2016-02-10T16:06:07Z",
           "pushedAt": "2020-05-07T19:59:14Z",
           "forks": 877,
           "issues": 34,
           "subscribers": 234,
-          "stars": 11200
+          "stars": 11203
         },
         "name": "ignite",
         "fullName": "infinitered/ignite",
@@ -8689,9 +9080,9 @@
         }
       },
       "npm": {
-        "downloads": 904,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 792,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -8719,13 +9110,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T23:20:49Z",
+          "updatedAt": "2020-05-12T17:08:31Z",
           "createdAt": "2015-06-09T19:25:38Z",
           "pushedAt": "2020-05-07T19:31:08Z",
-          "forks": 1374,
+          "forks": 1375,
           "issues": 106,
-          "subscribers": 363,
-          "stars": 16503
+          "subscribers": 362,
+          "stars": 16511
         },
         "name": "react-native-web",
         "fullName": "necolas/react-native-web",
@@ -8745,9 +9136,9 @@
         }
       },
       "npm": {
-        "downloads": 428504,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 437487,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -8799,9 +9190,9 @@
       },
       "npmPkg": "react-native-document-picker",
       "npm": {
-        "downloads": 87730,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 90641,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -8829,13 +9220,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T11:55:19Z",
+          "updatedAt": "2020-05-12T11:21:32Z",
           "createdAt": "2016-11-29T10:50:53Z",
           "pushedAt": "2020-05-07T18:36:09Z",
           "forks": 430,
           "issues": 122,
           "subscribers": 23,
-          "stars": 1561
+          "stars": 1563
         },
         "name": "react-native-render-html",
         "fullName": "archriss/react-native-render-html",
@@ -8859,9 +9250,9 @@
         }
       },
       "npm": {
-        "downloads": 149189,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 154211,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -8889,13 +9280,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T16:50:13Z",
+          "updatedAt": "2020-05-12T13:56:34Z",
           "createdAt": "2016-02-23T00:19:11Z",
           "pushedAt": "2020-05-07T17:54:25Z",
           "forks": 512,
           "issues": 177,
           "subscribers": 36,
-          "stars": 3041
+          "stars": 3042
         },
         "name": "react-native-config",
         "fullName": "luggit/react-native-config",
@@ -8911,9 +9302,9 @@
       },
       "npmPkg": "react-native-config",
       "npm": {
-        "downloads": 304794,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 316636,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -8967,9 +9358,9 @@
         }
       },
       "npm": {
-        "downloads": 586,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 594,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -8998,13 +9389,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T21:07:47Z",
+          "updatedAt": "2020-05-12T13:32:25Z",
           "createdAt": "2019-09-06T09:39:03Z",
           "pushedAt": "2020-05-07T14:02:39Z",
           "forks": 2,
           "issues": 0,
           "subscribers": 59,
-          "stars": 194
+          "stars": 196
         },
         "name": "restyle",
         "fullName": "Shopify/restyle",
@@ -9019,9 +9410,9 @@
         }
       },
       "npm": {
-        "downloads": 32,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 40,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -9048,13 +9439,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T11:39:48Z",
+          "updatedAt": "2020-05-12T16:26:22Z",
           "createdAt": "2015-08-03T17:10:14Z",
           "pushedAt": "2020-05-07T13:09:48Z",
           "forks": 800,
           "issues": 176,
           "subscribers": 74,
-          "stars": 2774
+          "stars": 2778
         },
         "name": "react-native-fbsdk",
         "fullName": "facebook/react-native-fbsdk",
@@ -9070,9 +9461,9 @@
       },
       "npmPkg": "react-native-fbsdk",
       "npm": {
-        "downloads": 188091,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 194312,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -9132,9 +9523,9 @@
       },
       "npmPkg": "react-native-simple-dialogs",
       "npm": {
-        "downloads": 7544,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7849,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -9191,9 +9582,9 @@
         }
       },
       "npm": {
-        "downloads": 2951,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3059,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -9223,13 +9614,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T22:27:40Z",
+          "updatedAt": "2020-05-12T17:21:25Z",
           "createdAt": "2017-01-27T18:24:50Z",
           "pushedAt": "2020-05-07T07:54:14Z",
-          "forks": 1375,
-          "issues": 80,
+          "forks": 1376,
+          "issues": 81,
           "subscribers": 258,
-          "stars": 12942
+          "stars": 12944
         },
         "name": "lottie-react-native",
         "fullName": "react-native-community/lottie-react-native",
@@ -9251,9 +9642,9 @@
       },
       "npmPkg": "lottie-react-native",
       "npm": {
-        "downloads": 347456,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 359790,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -9289,13 +9680,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T17:43:40Z",
+          "updatedAt": "2020-05-12T16:01:28Z",
           "createdAt": "2016-01-17T14:29:21Z",
           "pushedAt": "2020-05-07T07:08:57Z",
           "forks": 621,
-          "issues": 78,
+          "issues": 79,
           "subscribers": 86,
-          "stars": 4573
+          "stars": 4577
         },
         "name": "react-native-svg",
         "fullName": "react-native-community/react-native-svg",
@@ -9310,9 +9701,9 @@
         }
       },
       "npm": {
-        "downloads": 981316,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1014969,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -9344,13 +9735,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T20:08:25Z",
+          "updatedAt": "2020-05-12T17:10:55Z",
           "createdAt": "2017-03-12T10:57:40Z",
           "pushedAt": "2020-05-07T06:39:42Z",
-          "forks": 414,
-          "issues": 73,
-          "subscribers": 14,
-          "stars": 766
+          "forks": 416,
+          "issues": 72,
+          "subscribers": 13,
+          "stars": 767
         },
         "name": "react-native-material-textfield",
         "fullName": "n4kz/react-native-material-textfield",
@@ -9373,9 +9764,9 @@
       },
       "npmPkg": "react-native-material-textfield",
       "npm": {
-        "downloads": 118139,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 121617,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -9431,9 +9822,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 40631,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 41621,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -9468,7 +9859,7 @@
           "createdAt": "2019-02-08T15:50:15Z",
           "pushedAt": "2020-05-07T02:40:23Z",
           "forks": 79,
-          "issues": 48,
+          "issues": 47,
           "subscribers": 6,
           "stars": 186
         },
@@ -9485,9 +9876,9 @@
         }
       },
       "npm": {
-        "downloads": 229492,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 237959,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -9542,9 +9933,9 @@
         }
       },
       "npm": {
-        "downloads": 802,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 860,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -9598,9 +9989,9 @@
         }
       },
       "npm": {
-        "downloads": 572,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 598,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -9651,9 +10042,9 @@
       },
       "npmPkg": "datetimepicker",
       "npm": {
-        "downloads": 44332,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 46555,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -9664,13 +10055,14 @@
     },
     {
       "githubUrl": "https://github.com/expo/vector-icons",
+      "npmPkg": "@expo/vector-icons",
       "ios": true,
       "android": true,
       "web": true,
       "expo": true,
-      "npmPkg": "@expo/vector-icons",
+      "goldstar": true,
       "examples": [
-        "https://expo.github.io/vector-icons"
+        "https://icons.expo.io"
       ],
       "github": {
         "urls": {
@@ -9684,13 +10076,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T05:40:17Z",
+          "updatedAt": "2020-05-12T00:06:13Z",
           "createdAt": "2016-07-09T01:57:59Z",
           "pushedAt": "2020-05-07T00:13:42Z",
           "forks": 76,
           "issues": 10,
           "subscribers": 11,
-          "stars": 341
+          "stars": 342
         },
         "name": "vector-icons",
         "fullName": "expo/vector-icons",
@@ -9705,14 +10097,15 @@
         }
       },
       "npm": {
-        "downloads": 367273,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 377883,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
-      "score": 63,
+      "score": 75,
       "matchingScoreModifiers": [
         "Popular",
+        "Recommended",
         "Recently updated"
       ],
       "topicSearchString": ""
@@ -9734,11 +10127,11 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T09:54:53Z",
+          "updatedAt": "2020-05-12T13:03:57Z",
           "createdAt": "2015-11-30T10:23:11Z",
           "pushedAt": "2020-05-06T22:31:07Z",
-          "forks": 272,
-          "issues": 54,
+          "forks": 273,
+          "issues": 55,
           "subscribers": 16,
           "stars": 992
         },
@@ -9762,9 +10155,9 @@
       },
       "npmPkg": "react-native-image-resizer",
       "npm": {
-        "downloads": 92379,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 94992,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -9821,9 +10214,9 @@
         }
       },
       "npm": {
-        "downloads": 4350,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4463,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -9855,13 +10248,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-10T20:18:23Z",
+          "updatedAt": "2020-05-12T13:04:21Z",
           "createdAt": "2020-05-06T00:15:39Z",
           "pushedAt": "2020-05-06T20:45:42Z",
           "forks": 0,
           "issues": 0,
           "subscribers": 1,
-          "stars": 1
+          "stars": 2
         },
         "name": "react-native-kvideo",
         "fullName": "khalisafkari/react-native-kvideo",
@@ -9871,8 +10264,8 @@
       },
       "npm": {
         "downloads": 41,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -9902,13 +10295,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T12:26:43Z",
+          "updatedAt": "2020-05-12T17:14:23Z",
           "createdAt": "2017-07-29T14:39:19Z",
           "pushedAt": "2020-05-06T19:35:11Z",
           "forks": 190,
           "issues": 70,
           "subscribers": 13,
-          "stars": 747
+          "stars": 748
         },
         "name": "react-native-text-input-mask",
         "fullName": "react-native-community/react-native-text-input-mask",
@@ -9934,9 +10327,9 @@
         }
       },
       "npm": {
-        "downloads": 16117,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16656,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -10035,9 +10428,9 @@
         }
       },
       "npm": {
-        "downloads": 2619,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2710,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -10093,9 +10486,9 @@
       },
       "npmPkg": "react-native-extended-stylesheet",
       "npm": {
-        "downloads": 39453,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 40808,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -10125,13 +10518,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-10T20:58:20Z",
+          "updatedAt": "2020-05-12T07:45:07Z",
           "createdAt": "2015-12-15T21:24:33Z",
           "pushedAt": "2020-05-06T17:22:13Z",
-          "forks": 178,
+          "forks": 180,
           "issues": 9,
           "subscribers": 9,
-          "stars": 674
+          "stars": 675
         },
         "name": "react-native-action-sheet",
         "fullName": "expo/react-native-action-sheet",
@@ -10146,9 +10539,9 @@
         }
       },
       "npm": {
-        "downloads": 144098,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 148573,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -10182,7 +10575,7 @@
           "updatedAt": "2020-05-05T14:26:11Z",
           "createdAt": "2017-06-25T16:40:57Z",
           "pushedAt": "2020-05-06T17:03:28Z",
-          "forks": 19,
+          "forks": 20,
           "issues": 3,
           "subscribers": 5,
           "stars": 164
@@ -10200,9 +10593,9 @@
         }
       },
       "npm": {
-        "downloads": 33619,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 34886,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -10255,9 +10648,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 3825,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3969,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -10284,13 +10677,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-09T15:42:31Z",
+          "updatedAt": "2020-05-12T15:37:38Z",
           "createdAt": "2016-09-26T04:01:22Z",
           "pushedAt": "2020-05-06T16:04:52Z",
           "forks": 103,
           "issues": 8,
           "subscribers": 5,
-          "stars": 414
+          "stars": 416
         },
         "name": "react-native-segmented-control-tab",
         "fullName": "kirankalyan5/react-native-segmented-control-tab",
@@ -10306,9 +10699,9 @@
       },
       "npmPkg": "react-native-segmented-control-tab",
       "npm": {
-        "downloads": 82958,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 85840,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -10338,7 +10731,7 @@
           "updatedAt": "2020-05-11T08:13:37Z",
           "createdAt": "2017-11-21T09:44:14Z",
           "pushedAt": "2020-05-06T13:37:32Z",
-          "forks": 74,
+          "forks": 76,
           "issues": 2,
           "subscribers": 15,
           "stars": 1026
@@ -10361,9 +10754,9 @@
         }
       },
       "npm": {
-        "downloads": 30232,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 31269,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -10424,9 +10817,9 @@
       },
       "npmPkg": "react-native-sortable-list",
       "npm": {
-        "downloads": 15530,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16130,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -10455,11 +10848,11 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T17:12:22Z",
+          "updatedAt": "2020-05-12T10:05:39Z",
           "createdAt": "2016-10-27T09:03:49Z",
           "pushedAt": "2020-05-06T09:30:44Z",
           "forks": 400,
-          "issues": 187,
+          "issues": 186,
           "subscribers": 33,
           "stars": 948
         },
@@ -10483,9 +10876,9 @@
       },
       "npmPkg": "tipsi-stripe",
       "npm": {
-        "downloads": 47669,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 49543,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -10495,57 +10888,6 @@
         "Recently updated"
       ],
       "topicSearchString": " android apple-pay ios react-native stripe"
-    },
-    {
-      "githubUrl": "https://github.com/GetStream/stream-chat-react-native",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/GetStream/stream-chat-react-native",
-          "clone": "https://github.com/GetStream/stream-chat-react-native.git",
-          "homepage": "https://getstream.io/chat/react-native-chat/tutorial/"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": true,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T22:18:12Z",
-          "createdAt": "2019-03-28T08:50:26Z",
-          "pushedAt": "2020-05-06T09:23:02Z",
-          "forks": 51,
-          "issues": 26,
-          "subscribers": 18,
-          "stars": 105
-        },
-        "name": "stream-chat-react-native",
-        "fullName": "GetStream/stream-chat-react-native",
-        "description": "Stream Chat official react-native SDK. The tutorial covers how to build your own chat experience using react-native, react-navigation and Stream",
-        "topics": [],
-        "license": {
-          "key": "other",
-          "name": "Other",
-          "spdx_id": "NOASSERTION",
-          "url": null,
-          "node_id": "MDc6TGljZW5zZTA="
-        }
-      },
-      "npmPkg": "stream-chat-react-native",
-      "npm": {
-        "downloads": 6354,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": ""
     },
     {
       "githubUrl": "https://github.com/wix/react-native-keyboard-input",
@@ -10563,13 +10905,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T17:12:28Z",
+          "updatedAt": "2020-05-12T01:48:59Z",
           "createdAt": "2016-12-14T09:49:51Z",
           "pushedAt": "2020-05-06T07:15:12Z",
           "forks": 126,
-          "issues": 60,
-          "subscribers": 278,
-          "stars": 646
+          "issues": 61,
+          "subscribers": 277,
+          "stars": 647
         },
         "name": "react-native-keyboard-input",
         "fullName": "wix/react-native-keyboard-input",
@@ -10593,9 +10935,9 @@
       },
       "npmPkg": "react-native-keyboard-input",
       "npm": {
-        "downloads": 1887,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1942,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -10644,9 +10986,9 @@
         }
       },
       "npm": {
-        "downloads": 879,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 916,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -10673,13 +11015,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T16:00:11Z",
+          "updatedAt": "2020-05-12T18:12:25Z",
           "createdAt": "2018-02-11T22:31:55Z",
           "pushedAt": "2020-05-05T22:02:28Z",
-          "forks": 239,
+          "forks": 238,
           "issues": 14,
-          "subscribers": 11,
-          "stars": 819
+          "subscribers": 12,
+          "stars": 822
         },
         "name": "react-native-picker-select",
         "fullName": "lawnstarter/react-native-picker-select",
@@ -10702,9 +11044,9 @@
       },
       "npmPkg": "react-native-picker-select",
       "npm": {
-        "downloads": 153889,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 160219,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -10713,123 +11055,6 @@
         "Recently updated"
       ],
       "topicSearchString": " dropdown frontend picker react react-native select"
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/google-signin",
-      "ios": true,
-      "android": true,
-      "web": false,
-      "expo": false,
-      "examples": [],
-      "npmPkg": "@react-native-community/google-signin",
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/google-signin",
-          "clone": "https://github.com/react-native-community/google-signin.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T10:46:08Z",
-          "createdAt": "2015-08-13T06:13:57Z",
-          "pushedAt": "2020-05-05T19:45:29Z",
-          "forks": 702,
-          "issues": 28,
-          "subscribers": 45,
-          "stars": 1817
-        },
-        "name": "google-signin",
-        "fullName": "react-native-community/google-signin",
-        "description": "Google Sign-in for your React Native applications",
-        "topics": [
-          "googleauth",
-          "googlesignin",
-          "oauth2",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 86357,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " googleauth googlesignin oauth2 react-native"
-    },
-    {
-      "githubUrl": "https://github.com/react-native-community/react-native-google-signin",
-      "ios": true,
-      "android": true,
-      "expo": false,
-      "npmPkg": "react-native-google-signin",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/react-native-community/google-signin",
-          "clone": "https://github.com/react-native-community/google-signin.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T10:46:08Z",
-          "createdAt": "2015-08-13T06:13:57Z",
-          "pushedAt": "2020-05-05T19:45:29Z",
-          "forks": 702,
-          "issues": 28,
-          "subscribers": 45,
-          "stars": 1817
-        },
-        "name": "google-signin",
-        "fullName": "react-native-community/google-signin",
-        "description": "Google Sign-in for your React Native applications",
-        "topics": [
-          "googleauth",
-          "googlesignin",
-          "oauth2",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 35119,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 88,
-      "matchingScoreModifiers": [
-        "Very popular",
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " googleauth googlesignin oauth2 react-native"
     },
     {
       "githubUrl": "https://github.com/react-native-community/art",
@@ -10873,9 +11098,9 @@
         }
       },
       "npm": {
-        "downloads": 145582,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 151991,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -10904,13 +11129,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T19:22:16Z",
+          "updatedAt": "2020-05-12T15:47:23Z",
           "createdAt": "2016-09-23T16:45:46Z",
           "pushedAt": "2020-05-05T18:37:23Z",
           "forks": 446,
           "issues": 26,
           "subscribers": 43,
-          "stars": 3474
+          "stars": 3480
         },
         "name": "react-native-modal",
         "fullName": "react-native-community/react-native-modal",
@@ -10935,9 +11160,9 @@
       },
       "npmPkg": "react-native-modal",
       "npm": {
-        "downloads": 566169,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 586126,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -10987,9 +11212,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 76,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 77,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -11016,13 +11241,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T22:56:48Z",
+          "updatedAt": "2020-05-12T13:45:56Z",
           "createdAt": "2016-04-15T11:37:23Z",
           "pushedAt": "2020-05-05T16:27:52Z",
-          "forks": 1666,
+          "forks": 1667,
           "issues": 250,
           "subscribers": 258,
-          "stars": 13750
+          "stars": 13756
         },
         "name": "NativeBase",
         "fullName": "GeekyAnts/NativeBase",
@@ -11044,9 +11269,9 @@
         }
       },
       "npm": {
-        "downloads": 169269,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 172835,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -11103,9 +11328,9 @@
         }
       },
       "npm": {
-        "downloads": 6491,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6748,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -11132,13 +11357,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-09T23:56:51Z",
+          "updatedAt": "2020-05-12T16:36:27Z",
           "createdAt": "2018-04-18T05:50:46Z",
           "pushedAt": "2020-05-05T10:38:50Z",
           "forks": 62,
           "issues": 8,
-          "subscribers": 3,
-          "stars": 218
+          "subscribers": 2,
+          "stars": 219
         },
         "name": "react-native-walkthrough-tooltip",
         "fullName": "jasongaare/react-native-walkthrough-tooltip",
@@ -11158,9 +11383,9 @@
       },
       "npmPkg": "react-native-walkthrough-tooltip",
       "npm": {
-        "downloads": 25219,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 26254,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -11215,9 +11440,9 @@
       },
       "npmPkg": "instabug-reactnative",
       "npm": {
-        "downloads": 25216,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 26375,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -11269,9 +11494,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 626,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 655,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -11304,7 +11529,7 @@
           "pushedAt": "2020-05-04T23:15:54Z",
           "forks": 263,
           "issues": 160,
-          "subscribers": 207,
+          "subscribers": 206,
           "stars": 965
         },
         "name": "react-native-camera-kit",
@@ -11320,9 +11545,9 @@
         }
       },
       "npm": {
-        "downloads": 4232,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4346,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -11354,13 +11579,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T03:06:29Z",
+          "updatedAt": "2020-05-12T00:53:27Z",
           "createdAt": "2016-11-05T16:07:50Z",
           "pushedAt": "2020-05-04T21:18:02Z",
           "forks": 192,
           "issues": 83,
           "subscribers": 20,
-          "stars": 267
+          "stars": 268
         },
         "name": "react-native-twilio-video-webrtc",
         "fullName": "blackuy/react-native-twilio-video-webrtc",
@@ -11381,9 +11606,9 @@
         }
       },
       "npm": {
-        "downloads": 131,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 135,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -11442,9 +11667,9 @@
         }
       },
       "npm": {
-        "downloads": 21862,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 22624,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -11494,9 +11719,9 @@
       },
       "npmPkg": "react-native-gesture-recognizers",
       "npm": {
-        "downloads": 135,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 138,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -11520,13 +11745,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T21:12:59Z",
+          "updatedAt": "2020-05-12T03:28:24Z",
           "createdAt": "2016-03-24T16:33:42Z",
           "pushedAt": "2020-05-04T17:45:06Z",
           "forks": 591,
           "issues": 4,
           "subscribers": 25,
-          "stars": 2048
+          "stars": 2049
         },
         "name": "react-native-permissions",
         "fullName": "react-native-community/react-native-permissions",
@@ -11542,9 +11767,9 @@
       },
       "npmPkg": "react-native-permissions",
       "npm": {
-        "downloads": 389424,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 404012,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -11575,13 +11800,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T09:57:45Z",
+          "updatedAt": "2020-05-12T17:25:50Z",
           "createdAt": "2015-12-12T12:52:11Z",
           "pushedAt": "2020-05-04T13:00:25Z",
-          "forks": 638,
-          "issues": 17,
+          "forks": 639,
+          "issues": 16,
           "subscribers": 37,
-          "stars": 4911
+          "stars": 4916
         },
         "name": "react-i18next",
         "fullName": "i18next/react-i18next",
@@ -11604,9 +11829,9 @@
         }
       },
       "npm": {
-        "downloads": 2035006,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2114990,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -11637,13 +11862,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T02:06:27Z",
+          "updatedAt": "2020-05-12T15:28:39Z",
           "createdAt": "2017-09-17T11:37:11Z",
           "pushedAt": "2020-05-04T11:34:37Z",
-          "forks": 236,
+          "forks": 237,
           "issues": 79,
           "subscribers": 14,
-          "stars": 384
+          "stars": 385
         },
         "name": "rn-apple-healthkit",
         "fullName": "terrillo/rn-apple-healthkit",
@@ -11664,9 +11889,9 @@
       },
       "npmPkg": "rn-apple-healthkit",
       "npm": {
-        "downloads": 7768,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8104,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -11693,13 +11918,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T11:41:11Z",
+          "updatedAt": "2020-05-12T07:20:50Z",
           "createdAt": "2015-11-01T05:07:41Z",
           "pushedAt": "2020-05-04T09:14:55Z",
           "forks": 391,
           "issues": 92,
           "subscribers": 41,
-          "stars": 2747
+          "stars": 2749
         },
         "name": "react-native-progress",
         "fullName": "oblador/react-native-progress",
@@ -11715,9 +11940,9 @@
       },
       "npmPkg": "react-native-progress",
       "npm": {
-        "downloads": 167426,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 173127,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -11749,13 +11974,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T19:55:37Z",
+          "updatedAt": "2020-05-12T16:26:58Z",
           "createdAt": "2015-04-09T21:49:16Z",
           "pushedAt": "2020-05-04T08:47:38Z",
           "forks": 384,
           "issues": 112,
           "subscribers": 39,
-          "stars": 2802
+          "stars": 2803
         },
         "name": "react-native-blur",
         "fullName": "react-native-community/react-native-blur",
@@ -11774,9 +11999,9 @@
         }
       },
       "npm": {
-        "downloads": 89560,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 92380,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -11827,9 +12052,9 @@
         }
       },
       "npm": {
-        "downloads": 21653,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 22407,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -11885,9 +12110,9 @@
       },
       "npmPkg": "react-native-popup-dialog",
       "npm": {
-        "downloads": 35617,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 36685,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -11946,9 +12171,9 @@
       },
       "npmPkg": "react-native-modals",
       "npm": {
-        "downloads": 7667,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7848,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -11977,13 +12202,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T16:57:49Z",
+          "updatedAt": "2020-05-12T16:05:27Z",
           "createdAt": "2019-03-17T11:03:57Z",
           "pushedAt": "2020-05-03T19:18:10Z",
           "forks": 4,
           "issues": 2,
           "subscribers": 2,
-          "stars": 46
+          "stars": 47
         },
         "name": "react-native-svg-asset-plugin",
         "fullName": "aeirola/react-native-svg-asset-plugin",
@@ -12002,9 +12227,9 @@
       },
       "npmPkg": "react-native-svg-asset-plugin",
       "npm": {
-        "downloads": 2708,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2796,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12054,9 +12279,9 @@
       },
       "npmPkg": "react-native-safari-view",
       "npm": {
-        "downloads": 39676,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 41351,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12084,13 +12309,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T14:18:11Z",
+          "updatedAt": "2020-05-12T13:26:18Z",
           "createdAt": "2016-04-14T21:11:28Z",
           "pushedAt": "2020-05-03T13:53:23Z",
           "forks": 403,
           "issues": 20,
           "subscribers": 31,
-          "stars": 2011
+          "stars": 2012
         },
         "name": "react-native-swipe-list-view",
         "fullName": "jemise111/react-native-swipe-list-view",
@@ -12113,9 +12338,9 @@
         }
       },
       "npm": {
-        "downloads": 78346,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 81488,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -12171,9 +12396,9 @@
         }
       },
       "npm": {
-        "downloads": 21136,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 21870,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12202,13 +12427,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-09T21:04:06Z",
+          "updatedAt": "2020-05-12T10:09:46Z",
           "createdAt": "2019-02-07T10:53:29Z",
           "pushedAt": "2020-05-03T04:34:59Z",
           "forks": 13,
           "issues": 4,
           "subscribers": 3,
-          "stars": 55
+          "stars": 56
         },
         "name": "clipboard",
         "fullName": "react-native-community/clipboard",
@@ -12223,9 +12448,9 @@
         }
       },
       "npm": {
-        "downloads": 15908,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16730,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12251,13 +12476,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T15:53:05Z",
+          "updatedAt": "2020-05-12T12:18:59Z",
           "createdAt": "2015-07-27T12:49:29Z",
           "pushedAt": "2020-05-03T00:53:20Z",
           "forks": 260,
           "issues": 18,
           "subscribers": 46,
-          "stars": 2602
+          "stars": 2604
         },
         "name": "react-native-storage",
         "fullName": "sunnylqm/react-native-storage",
@@ -12279,9 +12504,9 @@
       },
       "npmPkg": "react-native-storage",
       "npm": {
-        "downloads": 20087,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 20592,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -12311,13 +12536,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T00:37:41Z",
+          "updatedAt": "2020-05-12T04:35:26Z",
           "createdAt": "2015-10-20T20:01:55Z",
           "pushedAt": "2020-05-02T21:46:03Z",
           "forks": 412,
           "issues": 71,
           "subscribers": 41,
-          "stars": 2204
+          "stars": 2205
         },
         "name": "react-native-action-button",
         "fullName": "mastermoo/react-native-action-button",
@@ -12338,9 +12563,9 @@
       },
       "npmPkg": "react-native-action-button",
       "npm": {
-        "downloads": 34825,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 35700,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -12396,9 +12621,9 @@
       },
       "npmPkg": "react-native-gradients",
       "npm": {
-        "downloads": 140,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 144,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12450,9 +12675,9 @@
       },
       "npmPkg": "react-native-dismiss-keyboard",
       "npm": {
-        "downloads": 172170,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 177640,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12500,9 +12725,9 @@
         }
       },
       "npm": {
-        "downloads": 918,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 929,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12531,13 +12756,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T20:36:31Z",
+          "updatedAt": "2020-05-12T14:40:46Z",
           "createdAt": "2017-04-08T18:16:46Z",
           "pushedAt": "2020-05-02T07:27:00Z",
           "forks": 298,
           "issues": 105,
           "subscribers": 21,
-          "stars": 1106
+          "stars": 1107
         },
         "name": "react-native-deck-swiper",
         "fullName": "alexbrillant/react-native-deck-swiper",
@@ -12560,9 +12785,9 @@
       },
       "npmPkg": "react-native-deck-swiper",
       "npm": {
-        "downloads": 7207,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7407,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -12595,7 +12820,7 @@
           "updatedAt": "2020-05-10T08:06:16Z",
           "createdAt": "2016-05-10T19:42:56Z",
           "pushedAt": "2020-05-01T10:28:44Z",
-          "forks": 146,
+          "forks": 147,
           "issues": 64,
           "subscribers": 20,
           "stars": 866
@@ -12613,9 +12838,9 @@
         }
       },
       "npm": {
-        "downloads": 69829,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 71616,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -12672,9 +12897,9 @@
       },
       "npmPkg": "react-native-google-photos",
       "npm": {
-        "downloads": 30,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 32,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12729,9 +12954,9 @@
       },
       "npmPkg": "react-native-webview-readability",
       "npm": {
-        "downloads": 34,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 35,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12779,9 +13004,9 @@
       },
       "npmPkg": "react-native-location",
       "npm": {
-        "downloads": 15507,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16196,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -12817,7 +13042,7 @@
           "pushedAt": "2020-04-30T08:51:46Z",
           "forks": 43,
           "issues": 3,
-          "subscribers": 8,
+          "subscribers": 7,
           "stars": 98
         },
         "name": "react-native-voip-push-notification",
@@ -12833,9 +13058,9 @@
         }
       },
       "npm": {
-        "downloads": 9301,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 9458,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12889,9 +13114,9 @@
       },
       "npmPkg": "react-native-instagram-login",
       "npm": {
-        "downloads": 2380,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2425,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12918,13 +13143,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-02T22:03:05Z",
+          "updatedAt": "2020-05-12T07:03:21Z",
           "createdAt": "2018-04-30T15:09:24Z",
           "pushedAt": "2020-04-29T20:01:16Z",
           "forks": 13,
           "issues": 1,
           "subscribers": 5,
-          "stars": 57
+          "stars": 58
         },
         "name": "react-native-wifi-p2p",
         "fullName": "kirillzyusko/react-native-wifi-p2p",
@@ -12940,9 +13165,9 @@
       },
       "npmPkg": "react-native-wifi-p2p",
       "npm": {
-        "downloads": 237,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 238,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -12976,7 +13201,7 @@
           "createdAt": "2017-01-12T10:04:59Z",
           "pushedAt": "2020-04-29T18:41:27Z",
           "forks": 113,
-          "issues": 38,
+          "issues": 39,
           "subscribers": 8,
           "stars": 157
         },
@@ -12993,9 +13218,9 @@
         }
       },
       "npm": {
-        "downloads": 6106,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6370,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -13046,9 +13271,9 @@
         }
       },
       "npm": {
-        "downloads": 26325,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 27755,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -13097,9 +13322,9 @@
       },
       "npmPkg": "rn-secure-storage",
       "npm": {
-        "downloads": 6771,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7177,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -13141,9 +13366,9 @@
       },
       "npmPkg": "react-native-ux-cam",
       "npm": {
-        "downloads": 14628,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14904,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -13197,9 +13422,9 @@
         }
       },
       "npm": {
-        "downloads": 70272,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 71932,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -13252,9 +13477,9 @@
         }
       },
       "npm": {
-        "downloads": 11208,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 11350,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -13287,7 +13512,7 @@
           "createdAt": "2016-11-03T00:54:01Z",
           "pushedAt": "2020-04-29T01:24:47Z",
           "forks": 324,
-          "issues": 26,
+          "issues": 25,
           "subscribers": 6,
           "stars": 374
         },
@@ -13314,9 +13539,9 @@
         }
       },
       "npm": {
-        "downloads": 17687,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 18430,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -13379,9 +13604,9 @@
       },
       "npmPkg": "react-native-onesignal",
       "npm": {
-        "downloads": 72794,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 75021,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -13434,9 +13659,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 163,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 165,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -13484,9 +13709,9 @@
         }
       },
       "npm": {
-        "downloads": 32216,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 33609,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -13543,9 +13768,9 @@
         }
       },
       "npm": {
-        "downloads": 4444,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4619,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -13584,7 +13809,7 @@
           "createdAt": "2017-03-27T18:21:49Z",
           "pushedAt": "2020-04-27T19:09:12Z",
           "forks": 219,
-          "issues": 7,
+          "issues": 6,
           "subscribers": 26,
           "stars": 1610
         },
@@ -13607,9 +13832,9 @@
         }
       },
       "npm": {
-        "downloads": 27840,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 28883,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -13658,9 +13883,9 @@
         }
       },
       "npm": {
-        "downloads": 3675,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3803,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -13687,13 +13912,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T22:17:40Z",
+          "updatedAt": "2020-05-12T13:59:40Z",
           "createdAt": "2017-04-25T15:12:58Z",
           "pushedAt": "2020-04-27T16:07:27Z",
-          "forks": 250,
+          "forks": 251,
           "issues": 68,
           "subscribers": 13,
-          "stars": 760
+          "stars": 762
         },
         "name": "react-native-pdf",
         "fullName": "wonday/react-native-pdf",
@@ -13716,9 +13941,9 @@
       },
       "npmPkg": "react-native-pdf",
       "npm": {
-        "downloads": 98410,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 102590,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -13727,61 +13952,6 @@
         "Recently updated"
       ],
       "topicSearchString": " android ios java objective-c pdf react-native"
-    },
-    {
-      "githubUrl": "https://github.com/oblador/react-native-keychain",
-      "ios": true,
-      "android": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/oblador/react-native-keychain",
-          "clone": "https://github.com/oblador/react-native-keychain.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T21:36:57Z",
-          "createdAt": "2015-05-20T15:33:48Z",
-          "pushedAt": "2020-04-27T07:25:14Z",
-          "forks": 303,
-          "issues": 65,
-          "subscribers": 26,
-          "stars": 1705
-        },
-        "name": "react-native-keychain",
-        "fullName": "oblador/react-native-keychain",
-        "description": ":key: Keychain Access for React Native",
-        "topics": [
-          "android",
-          "ios",
-          "keychain-access",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-keychain",
-      "npm": {
-        "downloads": 181317,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 63,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Recently updated"
-      ],
-      "topicSearchString": " android ios keychain-access react-native"
     },
     {
       "githubUrl": "https://github.com/moschan/react-native-flip-card",
@@ -13827,9 +13997,9 @@
       },
       "npmPkg": "react-native-flip-card",
       "npm": {
-        "downloads": 35538,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 36324,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -13878,9 +14048,9 @@
         }
       },
       "npm": {
-        "downloads": 10741,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 11063,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -13908,13 +14078,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T21:20:54Z",
+          "updatedAt": "2020-05-12T14:43:32Z",
           "createdAt": "2019-03-19T00:13:19Z",
           "pushedAt": "2020-04-26T21:33:37Z",
           "forks": 179,
           "issues": 99,
           "subscribers": 26,
-          "stars": 1807
+          "stars": 1810
         },
         "name": "react-native-reanimated-bottom-sheet",
         "fullName": "osdnk/react-native-reanimated-bottom-sheet",
@@ -13929,9 +14099,9 @@
         }
       },
       "npm": {
-        "downloads": 59957,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 62240,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -13981,9 +14151,9 @@
       },
       "npmPkg": "react-native-textinput-effects",
       "npm": {
-        "downloads": 5754,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5927,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -14035,9 +14205,9 @@
         }
       },
       "npm": {
-        "downloads": 8018,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8133,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -14064,13 +14234,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T22:55:39Z",
+          "updatedAt": "2020-05-12T15:29:50Z",
           "createdAt": "2016-09-14T10:43:55Z",
           "pushedAt": "2020-04-26T10:54:03Z",
           "forks": 796,
           "issues": 270,
           "subscribers": 59,
-          "stars": 4152
+          "stars": 4158
         },
         "name": "react-native-splash-screen",
         "fullName": "crazycodeboy/react-native-splash-screen",
@@ -14094,9 +14264,9 @@
       },
       "npmPkg": "react-native-splash-screen",
       "npm": {
-        "downloads": 323772,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 335786,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -14128,13 +14298,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T17:00:54Z",
+          "updatedAt": "2020-05-12T06:40:19Z",
           "createdAt": "2019-08-23T00:32:00Z",
           "pushedAt": "2020-04-25T23:55:22Z",
           "forks": 26,
           "issues": 12,
           "subscribers": 3,
-          "stars": 254
+          "stars": 256
         },
         "name": "react-native-appearance",
         "fullName": "expo/react-native-appearance",
@@ -14150,9 +14320,9 @@
       },
       "npmPkg": "react-native-appearance",
       "npm": {
-        "downloads": 75450,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 77339,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -14209,9 +14379,9 @@
         }
       },
       "npm": {
-        "downloads": 41016,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 42169,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -14243,13 +14413,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T22:55:38Z",
+          "updatedAt": "2020-05-12T12:17:06Z",
           "createdAt": "2019-07-02T10:45:52Z",
           "pushedAt": "2020-04-25T17:35:50Z",
           "forks": 53,
           "issues": 4,
           "subscribers": 9,
-          "stars": 752
+          "stars": 754
         },
         "name": "react-native-bootsplash",
         "fullName": "zoontek/react-native-bootsplash",
@@ -14264,9 +14434,9 @@
         }
       },
       "npm": {
-        "downloads": 37062,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 38432,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -14315,9 +14485,9 @@
       },
       "npmPkg": "react-scroll-paged-view",
       "npm": {
-        "downloads": 76,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 79,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -14369,8 +14539,8 @@
       },
       "npm": {
         "downloads": 258,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -14419,9 +14589,9 @@
         }
       },
       "npm": {
-        "downloads": 52776,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 54732,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -14454,7 +14624,7 @@
           "pushedAt": "2020-04-25T06:40:52Z",
           "forks": 106,
           "issues": 8,
-          "subscribers": 10,
+          "subscribers": 9,
           "stars": 567
         },
         "name": "react-native-qrcode-svg",
@@ -14476,9 +14646,9 @@
       },
       "npmPkg": "react-native-qrcode-svg",
       "npm": {
-        "downloads": 72796,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 75060,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -14526,9 +14696,9 @@
       },
       "npmPkg": "react-native-resegmented-control",
       "npm": {
-        "downloads": 624,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 660,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -14555,13 +14725,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-05T04:46:10Z",
+          "updatedAt": "2020-05-12T13:02:14Z",
           "createdAt": "2017-08-20T14:08:41Z",
           "pushedAt": "2020-04-25T00:56:49Z",
           "forks": 62,
           "issues": 17,
           "subscribers": 7,
-          "stars": 196
+          "stars": 197
         },
         "name": "react-native-perspective-image-cropper",
         "fullName": "Michaelvilleneuve/react-native-perspective-image-cropper",
@@ -14584,9 +14754,9 @@
       },
       "npmPkg": "react-native-perspective-image-cropper",
       "npm": {
-        "downloads": 185,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 203,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -14613,13 +14783,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T20:12:41Z",
+          "updatedAt": "2020-05-12T05:18:31Z",
           "createdAt": "2015-04-19T13:17:30Z",
           "pushedAt": "2020-04-25T00:41:55Z",
           "forks": 335,
           "issues": 22,
           "subscribers": 47,
-          "stars": 1773
+          "stars": 1774
         },
         "name": "react-native-background-geolocation",
         "fullName": "transistorsoft/react-native-background-geolocation",
@@ -14635,9 +14805,9 @@
       },
       "npmPkg": "react-native-background-geolocation",
       "npm": {
-        "downloads": 20340,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 21074,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -14686,9 +14856,9 @@
       },
       "npmPkg": "react-native-contacts",
       "npm": {
-        "downloads": 87499,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 89683,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -14737,9 +14907,9 @@
       },
       "npmPkg": "react-native-awesome-card-io",
       "npm": {
-        "downloads": 18128,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 18895,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -14768,7 +14938,7 @@
           "updatedAt": "2020-05-09T01:43:57Z",
           "createdAt": "2015-04-29T20:31:35Z",
           "pushedAt": "2020-04-24T14:19:20Z",
-          "forks": 259,
+          "forks": 258,
           "issues": 60,
           "subscribers": 47,
           "stars": 1558
@@ -14792,9 +14962,9 @@
       },
       "npmPkg": "react-native-chart",
       "npm": {
-        "downloads": 669,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 680,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -14843,9 +15013,9 @@
         }
       },
       "npm": {
-        "downloads": 2168,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2235,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -14872,13 +15042,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T01:36:51Z",
+          "updatedAt": "2020-05-12T04:34:41Z",
           "createdAt": "2016-08-23T20:02:58Z",
           "pushedAt": "2020-04-24T04:47:51Z",
-          "forks": 227,
+          "forks": 228,
           "issues": 29,
           "subscribers": 20,
-          "stars": 1484
+          "stars": 1485
         },
         "name": "react-native-view-shot",
         "fullName": "gre/react-native-view-shot",
@@ -14898,9 +15068,9 @@
       },
       "npmPkg": "react-native-view-shot",
       "npm": {
-        "downloads": 418330,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 428526,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -14961,9 +15131,9 @@
         }
       },
       "npm": {
-        "downloads": 699,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 721,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15006,9 +15176,9 @@
       },
       "npmPkg": "react-native-simple-toast",
       "npm": {
-        "downloads": 25235,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 26117,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15038,7 +15208,7 @@
           "pushedAt": "2020-04-23T14:24:58Z",
           "forks": 118,
           "issues": 35,
-          "subscribers": 189,
+          "subscribers": 188,
           "stars": 407
         },
         "name": "react-native-autogrow-textinput",
@@ -15055,9 +15225,9 @@
       },
       "npmPkg": "react-native-autogrow-textinput",
       "npm": {
-        "downloads": 11115,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 11548,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -15116,9 +15286,9 @@
       },
       "npmPkg": "react-native-formawesome",
       "npm": {
-        "downloads": 25,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 26,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15175,8 +15345,8 @@
       "npmPkg": "react-native-toastboard",
       "npm": {
         "downloads": 30,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15221,9 +15391,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 13010,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 13570,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -15255,13 +15425,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T17:54:59Z",
+          "updatedAt": "2020-05-12T16:45:56Z",
           "createdAt": "2018-09-07T06:39:07Z",
           "pushedAt": "2020-04-23T03:58:09Z",
           "forks": 77,
           "issues": 26,
           "subscribers": 6,
-          "stars": 377
+          "stars": 378
         },
         "name": "react-native-inappbrowser",
         "fullName": "proyecto26/react-native-inappbrowser",
@@ -15296,9 +15466,9 @@
         }
       },
       "npm": {
-        "downloads": 81208,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 84805,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15354,9 +15524,9 @@
       },
       "npmPkg": "rn-pdf-reader-js",
       "npm": {
-        "downloads": 2634,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2749,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15384,13 +15554,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T13:06:19Z",
+          "updatedAt": "2020-05-12T03:33:31Z",
           "createdAt": "2015-10-19T06:22:23Z",
           "pushedAt": "2020-04-22T21:02:48Z",
           "forks": 585,
           "issues": 237,
           "subscribers": 40,
-          "stars": 2112
+          "stars": 2113
         },
         "name": "react-native-sound",
         "fullName": "zmxv/react-native-sound",
@@ -15405,9 +15575,9 @@
         }
       },
       "npm": {
-        "downloads": 81814,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 84930,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -15462,9 +15632,9 @@
       },
       "npmPkg": "react-native-material-bottom-navigation",
       "npm": {
-        "downloads": 4808,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4954,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15494,13 +15664,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T08:29:43Z",
+          "updatedAt": "2020-05-12T01:44:46Z",
           "createdAt": "2019-02-07T10:42:47Z",
           "pushedAt": "2020-04-22T18:00:14Z",
           "forks": 30,
           "issues": 12,
           "subscribers": 7,
-          "stars": 302
+          "stars": 303
         },
         "name": "react-native-masked-view",
         "fullName": "react-native-community/react-native-masked-view",
@@ -15512,9 +15682,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 592496,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 608627,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -15539,13 +15709,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T20:52:38Z",
+          "updatedAt": "2020-05-12T00:05:15Z",
           "createdAt": "2016-08-01T18:44:54Z",
           "pushedAt": "2020-04-22T17:03:50Z",
           "forks": 125,
-          "issues": 7,
+          "issues": 8,
           "subscribers": 19,
-          "stars": 766
+          "stars": 767
         },
         "name": "react-native-background-fetch",
         "fullName": "transistorsoft/react-native-background-fetch",
@@ -15561,9 +15731,9 @@
       },
       "npmPkg": "react-native-background-fetch",
       "npm": {
-        "downloads": 58178,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 60133,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -15620,9 +15790,9 @@
       },
       "npmPkg": "react-native-add-calendar-event",
       "npm": {
-        "downloads": 34014,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 35225,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15650,13 +15820,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-10T20:02:30Z",
+          "updatedAt": "2020-05-12T06:23:30Z",
           "createdAt": "2017-03-22T19:15:24Z",
           "pushedAt": "2020-04-22T05:16:23Z",
           "forks": 563,
           "issues": 70,
           "subscribers": 268,
-          "stars": 8131
+          "stars": 8132
         },
         "name": "reactxp",
         "fullName": "microsoft/reactxp",
@@ -15671,9 +15841,9 @@
         }
       },
       "npm": {
-        "downloads": 5600,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5803,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -15728,9 +15898,9 @@
         }
       },
       "npm": {
-        "downloads": 21577,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 22543,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15761,7 +15931,7 @@
           "pushedAt": "2020-04-21T20:34:38Z",
           "forks": 479,
           "issues": 166,
-          "subscribers": 33,
+          "subscribers": 32,
           "stars": 2582
         },
         "name": "react-native-modalbox",
@@ -15778,9 +15948,9 @@
       },
       "npmPkg": "react-native-modalbox",
       "npm": {
-        "downloads": 55657,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 57584,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -15810,13 +15980,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T15:52:26Z",
+          "updatedAt": "2020-05-12T07:43:37Z",
           "createdAt": "2017-10-06T17:32:03Z",
           "pushedAt": "2020-04-21T19:13:55Z",
           "forks": 236,
           "issues": 63,
           "subscribers": 12,
-          "stars": 1305
+          "stars": 1307
         },
         "name": "react-native-copilot",
         "fullName": "mohebifar/react-native-copilot",
@@ -15835,9 +16005,9 @@
         }
       },
       "npm": {
-        "downloads": 8502,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8551,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -15895,9 +16065,9 @@
         }
       },
       "npm": {
-        "downloads": 12645,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 12964,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -15946,9 +16116,9 @@
         }
       },
       "npm": {
-        "downloads": 7457,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7793,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16002,9 +16172,9 @@
       },
       "npmPkg": "react-native-batch-push",
       "npm": {
-        "downloads": 283,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 302,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16030,13 +16200,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-10T15:38:12Z",
+          "updatedAt": "2020-05-12T13:56:33Z",
           "createdAt": "2015-08-25T11:12:44Z",
           "pushedAt": "2020-04-21T09:23:01Z",
           "forks": 2149,
           "issues": 199,
           "subscribers": 216,
-          "stars": 8770
+          "stars": 8772
         },
         "name": "react-native-router-flux",
         "fullName": "aksonov/react-native-router-flux",
@@ -16052,9 +16222,9 @@
       },
       "npmPkg": "react-native-router-flux",
       "npm": {
-        "downloads": 51294,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 52348,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -16083,13 +16253,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-10T11:16:42Z",
+          "updatedAt": "2020-05-12T17:37:47Z",
           "createdAt": "2016-07-27T10:57:27Z",
           "pushedAt": "2020-04-20T19:36:46Z",
-          "forks": 276,
+          "forks": 277,
           "issues": 35,
-          "subscribers": 59,
-          "stars": 1692
+          "subscribers": 60,
+          "stars": 1696
         },
         "name": "react-native-ble-plx",
         "fullName": "Polidea/react-native-ble-plx",
@@ -16105,9 +16275,9 @@
       },
       "npmPkg": "react-native-ble-plx",
       "npm": {
-        "downloads": 19493,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 20328,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -16164,9 +16334,9 @@
       },
       "npmPkg": "react-native-orientation-locker",
       "npm": {
-        "downloads": 66406,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 68943,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16194,13 +16364,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T17:22:23Z",
+          "updatedAt": "2020-05-12T14:00:47Z",
           "createdAt": "2018-03-05T14:04:44Z",
           "pushedAt": "2020-04-20T14:18:33Z",
           "forks": 76,
           "issues": 23,
           "subscribers": 8,
-          "stars": 526
+          "stars": 527
         },
         "name": "react-native-flash-message",
         "fullName": "lucasferreira/react-native-flash-message",
@@ -16220,9 +16390,9 @@
         }
       },
       "npm": {
-        "downloads": 34429,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 35508,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16271,9 +16441,9 @@
       },
       "npmPkg": "react-native-azure-auth",
       "npm": {
-        "downloads": 1984,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2048,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16327,9 +16497,9 @@
         }
       },
       "npm": {
-        "downloads": 39,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 38,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16358,13 +16528,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T19:57:55Z",
+          "updatedAt": "2020-05-12T08:03:27Z",
           "createdAt": "2019-05-29T19:16:31Z",
           "pushedAt": "2020-04-19T14:20:33Z",
           "forks": 27,
           "issues": 8,
           "subscribers": 17,
-          "stars": 701
+          "stars": 702
         },
         "name": "react-native-shared-element",
         "fullName": "IjzerenHein/react-native-shared-element",
@@ -16389,9 +16559,9 @@
       },
       "npmPkg": "react-native-shared-element",
       "npm": {
-        "downloads": 10869,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 11083,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16419,13 +16589,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T10:35:44Z",
+          "updatedAt": "2020-05-11T23:32:06Z",
           "createdAt": "2015-06-02T17:19:20Z",
           "pushedAt": "2020-04-19T08:45:49Z",
           "forks": 1034,
           "issues": 79,
           "subscribers": 216,
-          "stars": 6774
+          "stars": 6775
         },
         "name": "react-native-code-push",
         "fullName": "microsoft/react-native-code-push",
@@ -16444,9 +16614,9 @@
         }
       },
       "npm": {
-        "downloads": 247970,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 256852,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -16483,7 +16653,7 @@
           "createdAt": "2020-04-16T13:30:06Z",
           "pushedAt": "2020-04-19T02:54:44Z",
           "forks": 0,
-          "issues": 2,
+          "issues": 3,
           "subscribers": 2,
           "stars": 8
         },
@@ -16499,9 +16669,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 1403,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1524,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16551,9 +16721,9 @@
         }
       },
       "npm": {
-        "downloads": 631,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 630,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16578,13 +16748,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-09T07:38:45Z",
+          "updatedAt": "2020-05-12T13:23:48Z",
           "createdAt": "2015-06-14T10:48:33Z",
           "pushedAt": "2020-04-18T20:23:21Z",
           "forks": 356,
           "issues": 57,
           "subscribers": 31,
-          "stars": 2040
+          "stars": 2039
         },
         "name": "react-native-i18n",
         "fullName": "AlexanderZaytsev/react-native-i18n",
@@ -16600,9 +16770,9 @@
       },
       "npmPkg": "react-native-i18n",
       "npm": {
-        "downloads": 70201,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 72468,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -16651,9 +16821,9 @@
         }
       },
       "npm": {
-        "downloads": 31846,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 33128,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16679,13 +16849,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-04T06:11:12Z",
+          "updatedAt": "2020-05-12T07:05:55Z",
           "createdAt": "2015-11-05T16:33:08Z",
           "pushedAt": "2020-04-18T08:41:34Z",
           "forks": 112,
           "issues": 32,
           "subscribers": 11,
-          "stars": 256
+          "stars": 257
         },
         "name": "react-native-send-intent",
         "fullName": "lucasferreira/react-native-send-intent",
@@ -16695,9 +16865,9 @@
       },
       "npmPkg": "react-native-send-intent",
       "npm": {
-        "downloads": 17562,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 17980,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16724,13 +16894,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T13:04:44Z",
+          "updatedAt": "2020-05-12T15:27:19Z",
           "createdAt": "2015-10-20T18:22:34Z",
           "pushedAt": "2020-04-17T19:28:58Z",
           "forks": 420,
           "issues": 89,
           "subscribers": 41,
-          "stars": 3611
+          "stars": 3614
         },
         "name": "react-native-keyboard-aware-scroll-view",
         "fullName": "APSL/react-native-keyboard-aware-scroll-view",
@@ -16752,9 +16922,9 @@
         }
       },
       "npm": {
-        "downloads": 524178,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 542511,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -16787,13 +16957,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T09:26:28Z",
+          "updatedAt": "2020-05-12T09:45:55Z",
           "createdAt": "2015-03-31T17:44:40Z",
           "pushedAt": "2020-04-17T11:59:07Z",
           "forks": 492,
           "issues": 78,
           "subscribers": 44,
-          "stars": 3492
+          "stars": 3493
         },
         "name": "react-native-linear-gradient",
         "fullName": "react-native-community/react-native-linear-gradient",
@@ -16808,9 +16978,9 @@
         }
       },
       "npm": {
-        "downloads": 525865,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 545119,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -16865,9 +17035,9 @@
       },
       "npmPkg": "react-native-vkontakte-login",
       "npm": {
-        "downloads": 899,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 906,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -16938,9 +17108,9 @@
         }
       },
       "npm": {
-        "downloads": 343,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 356,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -17013,9 +17183,9 @@
         }
       },
       "npm": {
-        "downloads": 410,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 429,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -17042,13 +17212,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-03T17:58:17Z",
+          "updatedAt": "2020-05-12T06:51:10Z",
           "createdAt": "2017-12-13T22:39:37Z",
           "pushedAt": "2020-04-16T13:21:29Z",
           "forks": 84,
           "issues": 73,
           "subscribers": 12,
-          "stars": 211
+          "stars": 212
         },
         "name": "expo-pixi",
         "fullName": "expo/expo-pixi",
@@ -17070,9 +17240,9 @@
       },
       "npmPkg": "expo-pixi",
       "npm": {
-        "downloads": 2482,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2567,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -17099,13 +17269,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T14:56:42Z",
+          "updatedAt": "2020-05-12T17:07:30Z",
           "createdAt": "2016-03-24T15:40:53Z",
           "pushedAt": "2020-04-16T13:16:39Z",
           "forks": 576,
           "issues": 178,
           "subscribers": 90,
-          "stars": 3398
+          "stars": 3402
         },
         "name": "react-native-material-ui",
         "fullName": "xotahal/react-native-material-ui",
@@ -17127,9 +17297,9 @@
       },
       "npmPkg": "react-native-material-ui",
       "npm": {
-        "downloads": 16108,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16589,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -17164,7 +17334,7 @@
           "updatedAt": "2020-05-11T10:37:50Z",
           "createdAt": "2019-03-29T16:41:44Z",
           "pushedAt": "2020-04-16T12:48:34Z",
-          "forks": 83,
+          "forks": 84,
           "issues": 55,
           "subscribers": 18,
           "stars": 407
@@ -17182,9 +17352,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 292225,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 302290,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -17212,13 +17382,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T14:02:03Z",
+          "updatedAt": "2020-05-12T17:35:35Z",
           "createdAt": "2018-04-08T18:31:00Z",
           "pushedAt": "2020-04-16T05:41:12Z",
           "forks": 89,
-          "issues": 11,
+          "issues": 12,
           "subscribers": 6,
-          "stars": 436
+          "stars": 441
         },
         "name": "react-native-date-picker",
         "fullName": "henninghall/react-native-date-picker",
@@ -17242,9 +17412,9 @@
       },
       "npmPkg": "react-native-date-picker",
       "npm": {
-        "downloads": 48007,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 49980,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -17291,9 +17461,9 @@
         }
       },
       "npm": {
-        "downloads": 95899,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 99849,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -17319,13 +17489,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-09T16:36:31Z",
+          "updatedAt": "2020-05-12T01:40:22Z",
           "createdAt": "2016-10-04T17:41:20Z",
           "pushedAt": "2020-04-16T01:03:15Z",
           "forks": 161,
           "issues": 60,
           "subscribers": 23,
-          "stars": 1082
+          "stars": 1083
         },
         "name": "react-native-masked-text",
         "fullName": "benhurott/react-native-masked-text",
@@ -17345,9 +17515,9 @@
       },
       "npmPkg": "react-native-masked-text",
       "npm": {
-        "downloads": 121685,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 125660,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -17395,9 +17565,9 @@
       },
       "npmPkg": "react-native-intercom",
       "npm": {
-        "downloads": 69049,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 71754,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -17457,9 +17627,9 @@
       },
       "npmPkg": "react-native-onboarding-swiper",
       "npm": {
-        "downloads": 11043,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 11121,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -17489,7 +17659,7 @@
           "updatedAt": "2020-05-11T16:26:51Z",
           "createdAt": "2016-07-01T14:02:30Z",
           "pushedAt": "2020-04-15T15:50:29Z",
-          "forks": 260,
+          "forks": 261,
           "issues": 40,
           "subscribers": 11,
           "stars": 462
@@ -17508,9 +17678,9 @@
       },
       "npmPkg": "react-native-multi-slider",
       "npm": {
-        "downloads": 1218,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1253,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -17569,9 +17739,9 @@
         }
       },
       "npm": {
-        "downloads": 6163,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6376,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -17599,13 +17769,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T06:49:42Z",
+          "updatedAt": "2020-05-12T13:33:29Z",
           "createdAt": "2017-10-30T09:28:29Z",
           "pushedAt": "2020-04-14T19:02:39Z",
           "forks": 233,
           "issues": 119,
           "subscribers": 18,
-          "stars": 1594
+          "stars": 1596
         },
         "name": "react-native-svg-charts",
         "fullName": "JesperLekland/react-native-svg-charts",
@@ -17628,9 +17798,9 @@
         }
       },
       "npm": {
-        "downloads": 71771,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 74345,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -17685,9 +17855,9 @@
         }
       },
       "npm": {
-        "downloads": 98578,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 102745,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -17737,9 +17907,9 @@
       },
       "npmPkg": "react-native-signature-capture",
       "npm": {
-        "downloads": 24889,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 26018,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -17769,13 +17939,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T21:15:22Z",
+          "updatedAt": "2020-05-12T13:24:15Z",
           "createdAt": "2015-05-15T16:38:57Z",
           "pushedAt": "2020-04-14T10:09:54Z",
-          "forks": 1581,
-          "issues": 260,
+          "forks": 1580,
+          "issues": 261,
           "subscribers": 217,
-          "stars": 13313
+          "stars": 13317
         },
         "name": "react-native-vector-icons",
         "fullName": "oblador/react-native-vector-icons",
@@ -17796,9 +17966,9 @@
       },
       "npmPkg": "react-native-vector-icons",
       "npm": {
-        "downloads": 792253,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 816895,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -17829,13 +17999,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T20:16:02Z",
+          "updatedAt": "2020-05-12T04:28:20Z",
           "createdAt": "2017-06-21T11:27:21Z",
           "pushedAt": "2020-04-13T23:52:44Z",
           "forks": 39,
           "issues": 8,
           "subscribers": 5,
-          "stars": 459
+          "stars": 460
         },
         "name": "react-native-keyboard-manager",
         "fullName": "douglasjunior/react-native-keyboard-manager",
@@ -17856,9 +18026,9 @@
       },
       "npmPkg": "react-native-keyboard-manager",
       "npm": {
-        "downloads": 14743,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 15456,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -17890,7 +18060,7 @@
           "updatedAt": "2020-05-11T04:58:21Z",
           "createdAt": "2018-03-05T19:15:51Z",
           "pushedAt": "2020-04-13T15:47:40Z",
-          "forks": 116,
+          "forks": 117,
           "issues": 1,
           "subscribers": 42,
           "stars": 799
@@ -17914,9 +18084,9 @@
         }
       },
       "npm": {
-        "downloads": 7541,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7560,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -17958,9 +18128,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 8046,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8202,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -17990,7 +18160,7 @@
           "updatedAt": "2020-05-10T08:16:42Z",
           "createdAt": "2015-08-10T15:23:48Z",
           "pushedAt": "2020-04-12T16:53:02Z",
-          "forks": 162,
+          "forks": 161,
           "issues": 5,
           "subscribers": 15,
           "stars": 619
@@ -18009,9 +18179,9 @@
       },
       "npmPkg": "react-native-dropdown",
       "npm": {
-        "downloads": 2946,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2962,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -18038,13 +18208,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T14:16:20Z",
+          "updatedAt": "2020-05-12T13:12:37Z",
           "createdAt": "2016-04-21T11:34:10Z",
           "pushedAt": "2020-04-12T02:04:31Z",
           "forks": 516,
           "issues": 245,
-          "subscribers": 31,
-          "stars": 1904
+          "subscribers": 29,
+          "stars": 1905
         },
         "name": "react-native-datepicker",
         "fullName": "xgfe/react-native-datepicker",
@@ -18060,9 +18230,9 @@
       },
       "npmPkg": "react-native-datepicker",
       "npm": {
-        "downloads": 118473,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 122546,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -18090,13 +18260,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T03:36:26Z",
+          "updatedAt": "2020-05-12T15:04:58Z",
           "createdAt": "2015-06-07T13:36:23Z",
           "pushedAt": "2020-04-11T13:40:09Z",
-          "forks": 353,
+          "forks": 354,
           "issues": 51,
           "subscribers": 34,
-          "stars": 1776
+          "stars": 1777
         },
         "name": "react-native-collapsible",
         "fullName": "oblador/react-native-collapsible",
@@ -18117,9 +18287,9 @@
       },
       "npmPkg": "react-native-collapsible",
       "npm": {
-        "downloads": 188308,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 195388,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -18179,9 +18349,9 @@
       },
       "npmPkg": "react-native-localize",
       "npm": {
-        "downloads": 281698,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 293105,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -18190,6 +18360,58 @@
         "Recently updated"
       ],
       "topicSearchString": " android globalization i18n internationalization ios language-detection react-native"
+    },
+    {
+      "githubUrl": "https://github.com/christianjuth/react-context-theming",
+      "ios": true,
+      "android": true,
+      "web": true,
+      "expo": true,
+      "windows": false,
+      "examples": [
+        "https://github.com/christianjuth/react-context-theming/tree/master/examples/expo",
+        "https://github.com/christianjuth/react-context-theming/tree/master/examples/cra"
+      ],
+      "npmPkg": "https://www.npmjs.com/package/react-context-theming",
+      "unmaintained": false,
+      "github": {
+        "urls": {
+          "repo": "https://github.com/christianjuth/react-context-theming",
+          "clone": "https://github.com/christianjuth/react-context-theming.git",
+          "homepage": ""
+        },
+        "stats": {
+          "hasIssues": true,
+          "hasWiki": true,
+          "hasPages": false,
+          "hasDownloads": true,
+          "hasTopics": false,
+          "updatedAt": "2020-05-12T18:13:25Z",
+          "createdAt": "2020-01-30T01:46:36Z",
+          "pushedAt": "2020-04-11T05:33:44Z",
+          "forks": 0,
+          "issues": 2,
+          "subscribers": 1,
+          "stars": 1
+        },
+        "name": "react-context-theming",
+        "fullName": "christianjuth/react-context-theming",
+        "description": "A library to dynamically theme React Native AND React.js using React's context API",
+        "topics": [],
+        "license": {
+          "key": "mit",
+          "name": "MIT License",
+          "spdx_id": "MIT",
+          "url": "https://api.github.com/licenses/mit",
+          "node_id": "MDc6TGljZW5zZTEz"
+        }
+      },
+      "npm": {},
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
+      "topicSearchString": ""
     },
     {
       "githubUrl": "https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution",
@@ -18241,9 +18463,9 @@
         }
       },
       "npm": {
-        "downloads": 203682,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 210606,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -18291,9 +18513,9 @@
       },
       "npmPkg": "react-native-tcp",
       "npm": {
-        "downloads": 15164,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 15576,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -18349,9 +18571,9 @@
       },
       "npmPkg": "react-native-snackbar",
       "npm": {
-        "downloads": 30651,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 31799,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -18403,9 +18625,9 @@
       },
       "npmPkg": "react-native-percentage-circle",
       "npm": {
-        "downloads": 1066,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1092,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -18413,61 +18635,6 @@
         "Recently updated"
       ],
       "topicSearchString": " circle percent react-native"
-    },
-    {
-      "githubUrl": "https://github.com/artyorsh/react-native-eva-icons",
-      "ios": true,
-      "android": true,
-      "web": true,
-      "expo": true,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/artyorsh/react-native-eva-icons",
-          "clone": "https://github.com/artyorsh/react-native-eva-icons.git",
-          "homepage": "https://github.com/akveo/eva-icons"
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-01T07:59:38Z",
-          "createdAt": "2019-05-26T14:37:53Z",
-          "pushedAt": "2020-04-08T11:14:30Z",
-          "forks": 4,
-          "issues": 1,
-          "subscribers": 4,
-          "stars": 132
-        },
-        "name": "react-native-eva-icons",
-        "fullName": "artyorsh/react-native-eva-icons",
-        "description": "⭐Eva Icons for React Native",
-        "topics": [
-          "eva-icons",
-          "icons-source",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-eva-icons",
-      "npm": {
-        "downloads": 15917,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": " eva-icons icons-source react-native"
     },
     {
       "githubUrl": "https://github.com/tienph6m/react-native-animated-spinkit",
@@ -18520,9 +18687,9 @@
         }
       },
       "npm": {
-        "downloads": 787,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 818,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -18553,7 +18720,7 @@
           "createdAt": "2017-05-31T23:34:03Z",
           "pushedAt": "2020-04-06T18:43:44Z",
           "forks": 59,
-          "issues": 63,
+          "issues": 62,
           "subscribers": 19,
           "stars": 351
         },
@@ -18578,9 +18745,9 @@
       },
       "npmPkg": "expo-three",
       "npm": {
-        "downloads": 7308,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7459,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -18636,9 +18803,9 @@
         }
       },
       "npm": {
-        "downloads": 90521,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 94404,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -18684,8 +18851,8 @@
       },
       "npm": {
         "downloads": 7,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -18736,9 +18903,9 @@
       },
       "npmPkg": "react-native-loader",
       "npm": {
-        "downloads": 4079,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4168,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -18746,68 +18913,6 @@
         "Recently updated"
       ],
       "topicSearchString": " android animated-spinners ios react-native"
-    },
-    {
-      "githubUrl": "https://github.com/sbycrosz/react-native-credit-card-input",
-      "ios": true,
-      "android": true,
-      "expo": true,
-      "examples": [
-        "https://snack.expo.io/rJ7q6PhSb"
-      ],
-      "github": {
-        "urls": {
-          "repo": "https://github.com/sbycrosz/react-native-credit-card-input",
-          "clone": "https://github.com/sbycrosz/react-native-credit-card-input.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": false,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-09T23:33:25Z",
-          "createdAt": "2016-09-01T05:39:55Z",
-          "pushedAt": "2020-04-06T06:49:19Z",
-          "forks": 499,
-          "issues": 77,
-          "subscribers": 24,
-          "stars": 1087
-        },
-        "name": "react-native-credit-card-input",
-        "fullName": "sbycrosz/react-native-credit-card-input",
-        "description": "Easy, cross-platform credit-card input for your React Native Project! Start accepting payment 💰 in your app today!",
-        "topics": [
-          "android",
-          "component",
-          "credit-card",
-          "ios",
-          "payment",
-          "react-native"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-credit-card-input",
-      "npm": {
-        "downloads": 21802,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 50,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " android component credit-card ios payment react-native"
     },
     {
       "githubUrl": "https://github.com/ptmt/react-native-macos",
@@ -18826,13 +18931,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T05:50:26Z",
+          "updatedAt": "2020-05-12T17:09:15Z",
           "createdAt": "2015-10-04T15:22:01Z",
           "pushedAt": "2020-04-05T21:25:08Z",
           "forks": 495,
           "issues": 57,
           "subscribers": 244,
-          "stars": 11475
+          "stars": 11476
         },
         "name": "react-native-macos",
         "fullName": "ptmt/react-native-macos",
@@ -18847,9 +18952,9 @@
         }
       },
       "npm": {
-        "downloads": 5826,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6079,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -18900,9 +19005,9 @@
         }
       },
       "npm": {
-        "downloads": 3631,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3690,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -18955,9 +19060,9 @@
         }
       },
       "npm": {
-        "downloads": 24910,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 25573,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -18983,13 +19088,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T13:02:00Z",
+          "updatedAt": "2020-05-12T07:12:24Z",
           "createdAt": "2015-07-01T12:33:24Z",
           "pushedAt": "2020-04-05T15:17:33Z",
           "forks": 586,
           "issues": 162,
           "subscribers": 111,
-          "stars": 4640
+          "stars": 4641
         },
         "name": "react-native-material-kit",
         "fullName": "xinthink/react-native-material-kit",
@@ -19008,9 +19113,9 @@
       },
       "npmPkg": "react-native-material-kit",
       "npm": {
-        "downloads": 6369,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6635,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -19037,13 +19142,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T10:58:53Z",
+          "updatedAt": "2020-05-12T18:06:04Z",
           "createdAt": "2016-12-15T15:59:10Z",
           "pushedAt": "2020-04-05T14:06:37Z",
           "forks": 89,
           "issues": 73,
           "subscribers": 18,
-          "stars": 610
+          "stars": 612
         },
         "name": "react-native-background-job",
         "fullName": "vikeri/react-native-background-job",
@@ -19063,9 +19168,9 @@
       },
       "npmPkg": "react-native-background-job",
       "npm": {
-        "downloads": 2453,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2534,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -19113,9 +19218,9 @@
       },
       "npmPkg": "react-native-sortable-listview",
       "npm": {
-        "downloads": 5814,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5988,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -19142,13 +19247,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T16:27:59Z",
+          "updatedAt": "2020-05-12T10:39:53Z",
           "createdAt": "2017-05-07T16:22:54Z",
           "pushedAt": "2020-04-05T12:17:58Z",
           "forks": 128,
           "issues": 4,
           "subscribers": 12,
-          "stars": 1447
+          "stars": 1449
         },
         "name": "rn-placeholder",
         "fullName": "mfrachet/rn-placeholder",
@@ -19169,9 +19274,9 @@
       },
       "npmPkg": "rn-placeholder",
       "npm": {
-        "downloads": 43031,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 44761,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -19220,9 +19325,9 @@
         ]
       },
       "npm": {
-        "downloads": 85,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 90,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -19268,9 +19373,9 @@
         ]
       },
       "npm": {
-        "downloads": 34,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 30,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -19316,9 +19421,9 @@
         ]
       },
       "npm": {
-        "downloads": 36,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 33,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -19366,8 +19471,8 @@
       },
       "npm": {
         "downloads": 16,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -19420,9 +19525,9 @@
       },
       "npmPkg": "react-native-event-listeners",
       "npm": {
-        "downloads": 22766,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 23761,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -19470,9 +19575,9 @@
       },
       "npmPkg": "react-native-statusbar-alert",
       "npm": {
-        "downloads": 6088,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6348,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -19526,9 +19631,9 @@
         }
       },
       "npm": {
-        "downloads": 16586,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 17262,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -19587,9 +19692,9 @@
       },
       "npmPkg": "react-native-super-ellipse-mask",
       "npm": {
-        "downloads": 1266,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1350,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -19638,9 +19743,9 @@
       },
       "npmPkg": "react-native-styled-dialogs",
       "npm": {
-        "downloads": 49,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 51,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -19669,7 +19774,7 @@
           "updatedAt": "2020-05-11T22:34:43Z",
           "createdAt": "2017-07-06T21:20:25Z",
           "pushedAt": "2020-04-05T05:45:41Z",
-          "forks": 157,
+          "forks": 158,
           "issues": 82,
           "subscribers": 7,
           "stars": 313
@@ -19687,9 +19792,9 @@
         }
       },
       "npm": {
-        "downloads": 50761,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 52564,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -19720,7 +19825,7 @@
           "updatedAt": "2020-05-11T22:54:37Z",
           "createdAt": "2015-12-16T02:33:09Z",
           "pushedAt": "2020-04-05T03:02:05Z",
-          "forks": 337,
+          "forks": 338,
           "issues": 86,
           "subscribers": 34,
           "stars": 1961
@@ -19739,9 +19844,9 @@
       },
       "npmPkg": "react-native-parallax-scroll-view",
       "npm": {
-        "downloads": 15250,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 15747,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -19770,13 +19875,13 @@
           "hasPages": true,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T14:29:35Z",
+          "updatedAt": "2020-05-12T18:01:47Z",
           "createdAt": "2015-08-17T15:49:51Z",
           "pushedAt": "2020-04-04T22:56:58Z",
           "forks": 128,
           "issues": 32,
           "subscribers": 46,
-          "stars": 2079
+          "stars": 2081
         },
         "name": "gl-react",
         "fullName": "gre/gl-react",
@@ -19798,9 +19903,9 @@
       },
       "npmPkg": "gl-react",
       "npm": {
-        "downloads": 4338,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4413,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -19850,9 +19955,9 @@
       },
       "npmPkg": "react-native-drawer",
       "npm": {
-        "downloads": 176473,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 181081,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -19884,13 +19989,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T18:12:22Z",
+          "updatedAt": "2020-05-12T10:45:15Z",
           "createdAt": "2016-05-10T17:13:13Z",
           "pushedAt": "2020-04-04T13:15:05Z",
-          "forks": 143,
+          "forks": 144,
           "issues": 56,
           "subscribers": 8,
-          "stars": 583
+          "stars": 584
         },
         "name": "react-native-sensitive-info",
         "fullName": "mCodex/react-native-sensitive-info",
@@ -19914,9 +20019,9 @@
         }
       },
       "npm": {
-        "downloads": 49301,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 51394,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -19969,9 +20074,9 @@
       },
       "npmPkg": "react-native-dialogs",
       "npm": {
-        "downloads": 17696,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 18438,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20000,7 +20105,7 @@
           "updatedAt": "2020-05-09T18:13:37Z",
           "createdAt": "2017-01-20T20:59:40Z",
           "pushedAt": "2020-04-04T10:56:13Z",
-          "forks": 224,
+          "forks": 225,
           "issues": 46,
           "subscribers": 14,
           "stars": 907
@@ -20025,9 +20130,9 @@
       },
       "npmPkg": "react-native-step-indicator",
       "npm": {
-        "downloads": 15045,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 15328,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -20058,7 +20163,7 @@
           "updatedAt": "2020-04-19T12:53:42Z",
           "createdAt": "2018-07-19T13:34:36Z",
           "pushedAt": "2020-04-02T14:08:55Z",
-          "forks": 22,
+          "forks": 21,
           "issues": 16,
           "subscribers": 1,
           "stars": 24
@@ -20077,9 +20182,9 @@
       },
       "npmPkg": "react-native-navybits-date-time-picker",
       "npm": {
-        "downloads": 1113,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1094,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20138,9 +20243,9 @@
         }
       },
       "npm": {
-        "downloads": 16574,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 17078,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20189,9 +20294,9 @@
       },
       "npmPkg": "react-native-braintree-payments-drop-in",
       "npm": {
-        "downloads": 1584,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1629,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -20215,13 +20320,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-04-30T05:35:03Z",
+          "updatedAt": "2020-05-12T05:31:50Z",
           "createdAt": "2016-09-03T09:01:24Z",
           "pushedAt": "2020-04-02T08:54:20Z",
           "forks": 163,
           "issues": 54,
           "subscribers": 11,
-          "stars": 465
+          "stars": 466
         },
         "name": "react-native-check-box",
         "fullName": "crazycodeboy/react-native-check-box",
@@ -20242,9 +20347,9 @@
       },
       "npmPkg": "react-native-check-box",
       "npm": {
-        "downloads": 52149,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 53684,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -20274,13 +20379,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T07:52:36Z",
+          "updatedAt": "2020-05-12T08:46:19Z",
           "createdAt": "2016-06-27T07:13:04Z",
           "pushedAt": "2020-04-01T17:17:07Z",
           "forks": 277,
           "issues": 108,
           "subscribers": 18,
-          "stars": 701
+          "stars": 704
         },
         "name": "react-native-audio-toolkit",
         "fullName": "react-native-community/react-native-audio-toolkit",
@@ -20299,9 +20404,9 @@
         }
       },
       "npm": {
-        "downloads": 7803,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8015,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -20359,9 +20464,9 @@
         }
       },
       "npm": {
-        "downloads": 2911,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2990,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20388,13 +20493,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-06T22:47:32Z",
+          "updatedAt": "2020-05-12T00:53:24Z",
           "createdAt": "2015-08-26T09:06:18Z",
           "pushedAt": "2020-04-01T01:58:37Z",
           "forks": 133,
           "issues": 15,
           "subscribers": 12,
-          "stars": 269
+          "stars": 270
         },
         "name": "react-native-zip-archive",
         "fullName": "mockingbot/react-native-zip-archive",
@@ -20417,9 +20522,9 @@
       },
       "npmPkg": "react-native-zip-archive",
       "npm": {
-        "downloads": 17558,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 18233,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20459,9 +20564,9 @@
       },
       "npmPkg": "react-native-privacy-snapshot",
       "npm": {
-        "downloads": 1297,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1410,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20510,9 +20615,9 @@
         }
       },
       "npm": {
-        "downloads": 13873,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14605,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20561,9 +20666,9 @@
       },
       "npmPkg": "react-native-image-cache-wrapper",
       "npm": {
-        "downloads": 3480,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3588,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20605,9 +20710,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 13071,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 13716,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 44,
@@ -20657,59 +20762,9 @@
         }
       },
       "npm": {
-        "downloads": 28022,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
-      "topicSearchString": ""
-    },
-    {
-      "githubUrl": "https://github.com/iamacup/react-native-markdown-display",
-      "ios": true,
-      "android": true,
-      "npmPkg": "react-native-markdown-display",
-      "unmaintained": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/iamacup/react-native-markdown-display",
-          "clone": "https://github.com/iamacup/react-native-markdown-display.git",
-          "homepage": null
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": false,
-          "updatedAt": "2020-05-11T22:35:29Z",
-          "createdAt": "2019-10-29T12:10:24Z",
-          "pushedAt": "2020-03-30T21:44:22Z",
-          "forks": 9,
-          "issues": 9,
-          "subscribers": 1,
-          "stars": 53
-        },
-        "name": "react-native-markdown-display",
-        "fullName": "iamacup/react-native-markdown-display",
-        "description": "React Native 100% compatible CommonMark renderer",
-        "topics": [],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npm": {
-        "downloads": 21475,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 28920,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20761,9 +20816,9 @@
         }
       },
       "npm": {
-        "downloads": 25382,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 26522,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20812,9 +20867,9 @@
       },
       "npmPkg": "react-navigation-props-mapper",
       "npm": {
-        "downloads": 21432,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 22151,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20865,9 +20920,9 @@
         }
       },
       "npm": {
-        "downloads": 41,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 44,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20925,9 +20980,9 @@
         }
       },
       "npm": {
-        "downloads": 266,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 265,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -20953,13 +21008,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-09T05:19:17Z",
+          "updatedAt": "2020-05-12T04:38:36Z",
           "createdAt": "2015-10-27T15:09:33Z",
           "pushedAt": "2020-03-27T22:52:46Z",
           "forks": 340,
           "issues": 28,
           "subscribers": 21,
-          "stars": 1527
+          "stars": 1528
         },
         "name": "react-native-circular-progress",
         "fullName": "bartgryszko/react-native-circular-progress",
@@ -20981,9 +21036,9 @@
       },
       "npmPkg": "react-native-circular-progress",
       "npm": {
-        "downloads": 61711,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 63403,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -21012,13 +21067,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T21:48:37Z",
+          "updatedAt": "2020-05-12T15:21:52Z",
           "createdAt": "2018-06-17T16:14:11Z",
           "pushedAt": "2020-03-27T20:01:44Z",
           "forks": 230,
           "issues": 53,
           "subscribers": 52,
-          "stars": 2046
+          "stars": 2051
         },
         "name": "galio",
         "fullName": "galio-org/galio",
@@ -21047,9 +21102,9 @@
         }
       },
       "npm": {
-        "downloads": 5666,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5652,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -21099,9 +21154,9 @@
         }
       },
       "npm": {
-        "downloads": 5450,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5573,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21128,13 +21183,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T16:56:37Z",
+          "updatedAt": "2020-05-12T16:06:28Z",
           "createdAt": "2018-08-02T19:29:21Z",
           "pushedAt": "2020-03-26T07:58:05Z",
           "forks": 26,
           "issues": 16,
           "subscribers": 3,
-          "stars": 347
+          "stars": 348
         },
         "name": "react-native-svg-transformer",
         "fullName": "kristerkari/react-native-svg-transformer",
@@ -21156,9 +21211,9 @@
       },
       "npmPkg": "react-native-svg-transformer",
       "npm": {
-        "downloads": 232098,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 241207,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -21187,7 +21242,7 @@
           "updatedAt": "2020-05-09T01:24:44Z",
           "createdAt": "2016-09-14T20:41:32Z",
           "pushedAt": "2020-03-25T13:07:20Z",
-          "forks": 216,
+          "forks": 217,
           "issues": 44,
           "subscribers": 15,
           "stars": 514
@@ -21209,9 +21264,9 @@
       },
       "npmPkg": "react-native-google-places",
       "npm": {
-        "downloads": 13229,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 13631,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -21262,9 +21317,9 @@
         }
       },
       "npm": {
-        "downloads": 981,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 999,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21293,13 +21348,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-08T13:15:56Z",
+          "updatedAt": "2020-05-12T12:12:30Z",
           "createdAt": "2016-02-22T14:38:28Z",
           "pushedAt": "2020-03-24T21:58:22Z",
           "forks": 193,
           "issues": 74,
-          "subscribers": 17,
-          "stars": 540
+          "subscribers": 16,
+          "stars": 541
         },
         "name": "react-native-autocomplete-input",
         "fullName": "mrlaessig/react-native-autocomplete-input",
@@ -21322,9 +21377,9 @@
       },
       "npmPkg": "react-native-autocomplete-input",
       "npm": {
-        "downloads": 37777,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 38472,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -21374,9 +21429,9 @@
         }
       },
       "npm": {
-        "downloads": 77225,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 79970,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -21427,9 +21482,9 @@
       },
       "npmPkg": "react-native-simple-store",
       "npm": {
-        "downloads": 13915,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14567,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21478,9 +21533,9 @@
         }
       },
       "npm": {
-        "downloads": 305770,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 314322,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -21540,9 +21595,9 @@
       },
       "npmPkg": "pinar",
       "npm": {
-        "downloads": 489,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 507,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21591,9 +21646,9 @@
       },
       "npmPkg": "react-native-modern-datepicker",
       "npm": {
-        "downloads": 223,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 231,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21645,9 +21700,9 @@
       },
       "npmPkg": "react-native-gradient-buttons",
       "npm": {
-        "downloads": 456,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 464,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21695,9 +21750,9 @@
       },
       "npmPkg": "react-native-text",
       "npm": {
-        "downloads": 4174,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4381,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21740,8 +21795,8 @@
       "npmPkg": "react-native-atoz-list",
       "npm": {
         "downloads": 281,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21770,7 +21825,7 @@
           "updatedAt": "2020-05-10T15:05:42Z",
           "createdAt": "2015-04-04T21:29:42Z",
           "pushedAt": "2020-03-21T10:57:54Z",
-          "forks": 406,
+          "forks": 405,
           "issues": 78,
           "subscribers": 41,
           "stars": 2147
@@ -21794,9 +21849,9 @@
       },
       "npmPkg": "react-native-side-menu",
       "npm": {
-        "downloads": 29468,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 30153,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -21853,9 +21908,9 @@
       },
       "npmPkg": "react-native-autolink",
       "npm": {
-        "downloads": 20619,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 21105,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21912,9 +21967,9 @@
       },
       "npmPkg": "react-native-globalize",
       "npm": {
-        "downloads": 3575,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3647,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -21963,9 +22018,9 @@
       },
       "npmPkg": "react-native-chip-view",
       "npm": {
-        "downloads": 374,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 397,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22022,9 +22077,9 @@
       },
       "npmPkg": "react-native-linkedin",
       "npm": {
-        "downloads": 3858,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3957,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22078,9 +22133,9 @@
       },
       "npmPkg": "react-native-tilt",
       "npm": {
-        "downloads": 2,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -22141,9 +22196,9 @@
       },
       "npmPkg": "react-native-swiper-flatlist",
       "npm": {
-        "downloads": 8308,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8592,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22211,9 +22266,9 @@
         }
       },
       "npm": {
-        "downloads": 21,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 24,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22243,13 +22298,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-04-19T11:31:05Z",
+          "updatedAt": "2020-05-12T11:48:05Z",
           "createdAt": "2018-03-02T11:53:44Z",
           "pushedAt": "2020-03-17T13:45:51Z",
           "forks": 10,
           "issues": 1,
           "subscribers": 108,
-          "stars": 14
+          "stars": 15
         },
         "name": "react-native-audio-session",
         "fullName": "BonnierNews/react-native-audio-session",
@@ -22271,9 +22326,9 @@
         }
       },
       "npm": {
-        "downloads": 2235,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2266,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22326,9 +22381,9 @@
         }
       },
       "npm": {
-        "downloads": 235,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 240,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22375,9 +22430,9 @@
       },
       "npmPkg": "react-native-mail",
       "npm": {
-        "downloads": 24429,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 25423,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -22426,9 +22481,9 @@
         }
       },
       "npm": {
-        "downloads": 91773,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 95056,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -22458,13 +22513,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T22:59:46Z",
+          "updatedAt": "2020-05-12T15:31:42Z",
           "createdAt": "2017-06-28T09:29:12Z",
           "pushedAt": "2020-03-16T09:41:14Z",
-          "forks": 880,
+          "forks": 881,
           "issues": 8,
           "subscribers": 139,
-          "stars": 6000
+          "stars": 6001
         },
         "name": "kittenTricks",
         "fullName": "akveo/kittenTricks",
@@ -22487,9 +22542,9 @@
         }
       },
       "npm": {
-        "downloads": 16232,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16875,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -22540,9 +22595,9 @@
       },
       "npmPkg": "react-native-iconic",
       "npm": {
-        "downloads": 18,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 19,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22569,13 +22624,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-08T06:10:45Z",
+          "updatedAt": "2020-05-12T00:30:58Z",
           "createdAt": "2018-06-07T14:22:34Z",
           "pushedAt": "2020-03-15T05:50:10Z",
           "forks": 5,
           "issues": 5,
           "subscribers": 5,
-          "stars": 157
+          "stars": 158
         },
         "name": "react-native-scroll-into-view",
         "fullName": "slorber/react-native-scroll-into-view",
@@ -22590,9 +22645,9 @@
         }
       },
       "npm": {
-        "downloads": 19681,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 20162,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22643,9 +22698,9 @@
         }
       },
       "npm": {
-        "downloads": 1644,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1663,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -22699,9 +22754,9 @@
       },
       "npmPkg": "react-native-ruler",
       "npm": {
-        "downloads": 16,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 19,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -22753,9 +22808,9 @@
         }
       },
       "npm": {
-        "downloads": 931,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 990,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -22808,9 +22863,9 @@
       },
       "npmPkg": "react-native-window-guard",
       "npm": {
-        "downloads": 328,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 341,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22861,9 +22916,9 @@
       },
       "npmPkg": "react-native-camera-roll-picker",
       "npm": {
-        "downloads": 5341,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5548,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -22911,9 +22966,9 @@
       },
       "npmPkg": "react-native-floating-label-text-input",
       "npm": {
-        "downloads": 1443,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1504,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -22959,9 +23014,9 @@
       },
       "npmPkg": "react-native-search-header",
       "npm": {
-        "downloads": 709,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 726,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23016,9 +23071,9 @@
       },
       "npmPkg": "react-native-customize-selected-date",
       "npm": {
-        "downloads": 46,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 43,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23074,9 +23129,9 @@
         }
       },
       "npm": {
-        "downloads": 5956,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6260,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23125,9 +23180,9 @@
       },
       "npmPkg": "react-native-siri-wave-view",
       "npm": {
-        "downloads": 111,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 112,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -23174,9 +23229,9 @@
       },
       "npmPkg": "react-native-lock-screen",
       "npm": {
-        "downloads": 81,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 84,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23226,8 +23281,8 @@
       "npmPkg": "react-native-download-button",
       "npm": {
         "downloads": 24,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -23277,9 +23332,9 @@
       },
       "npmPkg": "react-native-schemes-manager",
       "npm": {
-        "downloads": 51399,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 53939,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23327,9 +23382,9 @@
       },
       "npmPkg": "pouchdb-react-native",
       "npm": {
-        "downloads": 1420,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1447,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23359,13 +23414,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T21:21:47Z",
+          "updatedAt": "2020-05-12T12:37:27Z",
           "createdAt": "2015-10-18T02:04:35Z",
           "pushedAt": "2020-03-14T00:17:42Z",
           "forks": 645,
           "issues": 144,
           "subscribers": 109,
-          "stars": 7859
+          "stars": 7860
         },
         "name": "react-native-animatable",
         "fullName": "oblador/react-native-animatable",
@@ -23385,9 +23440,9 @@
       },
       "npmPkg": "react-native-animatable",
       "npm": {
-        "downloads": 664021,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 687827,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 88,
@@ -23447,9 +23502,9 @@
       },
       "npmPkg": "react-native-immutable-list-view",
       "npm": {
-        "downloads": 1127,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1198,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -23496,9 +23551,9 @@
       },
       "npmPkg": "react-native-multiple-select",
       "npm": {
-        "downloads": 7039,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7213,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -23557,9 +23612,9 @@
       },
       "npmPkg": "react-native-sms-retriever",
       "npm": {
-        "downloads": 11985,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 12880,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23621,9 +23676,9 @@
       },
       "npmPkg": "react-native-grid-list",
       "npm": {
-        "downloads": 1339,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1367,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23651,13 +23706,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T10:59:37Z",
+          "updatedAt": "2020-05-12T03:10:23Z",
           "createdAt": "2016-05-04T13:08:37Z",
           "pushedAt": "2020-03-12T20:19:46Z",
-          "forks": 1073,
+          "forks": 1074,
           "issues": 268,
           "subscribers": 52,
-          "stars": 2530
+          "stars": 2531
         },
         "name": "react-native-fetch-blob",
         "fullName": "wkh237/react-native-fetch-blob",
@@ -23682,9 +23737,9 @@
         }
       },
       "npm": {
-        "downloads": 27517,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 28041,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -23736,9 +23791,9 @@
       },
       "npmPkg": "react-native-page-control",
       "npm": {
-        "downloads": 4365,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4462,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23793,9 +23848,9 @@
         }
       },
       "npm": {
-        "downloads": 94,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 96,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -23856,9 +23911,9 @@
         }
       },
       "npm": {
-        "downloads": 45,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 44,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23907,9 +23962,9 @@
         }
       },
       "npm": {
-        "downloads": 29018,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 29705,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -23969,9 +24024,9 @@
       },
       "npmPkg": "react-native-nested-listview",
       "npm": {
-        "downloads": 583,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 622,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -23998,13 +24053,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-10T22:29:20Z",
+          "updatedAt": "2020-05-12T11:10:15Z",
           "createdAt": "2018-01-10T10:33:49Z",
           "pushedAt": "2020-03-02T04:13:22Z",
           "forks": 31,
           "issues": 9,
           "subscribers": 5,
-          "stars": 164
+          "stars": 165
         },
         "name": "react-native-text-size",
         "fullName": "aMarCruz/react-native-text-size",
@@ -24030,9 +24085,9 @@
         }
       },
       "npm": {
-        "downloads": 21776,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 22205,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24060,13 +24115,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-07T10:24:06Z",
+          "updatedAt": "2020-05-12T11:09:17Z",
           "createdAt": "2015-11-12T17:16:33Z",
           "pushedAt": "2020-03-01T17:05:47Z",
           "forks": 139,
           "issues": 20,
           "subscribers": 18,
-          "stars": 809
+          "stars": 810
         },
         "name": "react-native-parsed-text",
         "fullName": "taskrabbit/react-native-parsed-text",
@@ -24081,9 +24136,9 @@
         }
       },
       "npm": {
-        "downloads": 60116,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 62540,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -24127,9 +24182,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 6180,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6418,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24193,9 +24248,9 @@
       },
       "npmPkg": "react-native-input-spinner",
       "npm": {
-        "downloads": 1128,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1160,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24227,7 +24282,7 @@
           "updatedAt": "2020-05-08T18:38:06Z",
           "createdAt": "2015-03-30T21:55:57Z",
           "pushedAt": "2020-02-26T02:59:45Z",
-          "forks": 321,
+          "forks": 320,
           "issues": 52,
           "subscribers": 41,
           "stars": 1884
@@ -24245,9 +24300,9 @@
         }
       },
       "npm": {
-        "downloads": 6146,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6393,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -24301,9 +24356,9 @@
       },
       "npmPkg": "react-native-slider",
       "npm": {
-        "downloads": 78252,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 80345,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -24353,9 +24408,9 @@
       },
       "npmPkg": "react-native-oauth",
       "npm": {
-        "downloads": 388,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 398,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -24410,9 +24465,9 @@
       },
       "npmPkg": "react-native-pages",
       "npm": {
-        "downloads": 7685,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8032,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24474,9 +24529,9 @@
       },
       "npmPkg": "react-native-loading-spinner-overlay",
       "npm": {
-        "downloads": 55910,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 57318,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -24519,9 +24574,9 @@
       },
       "npmPkg": "react-native-motion-manager",
       "npm": {
-        "downloads": 16,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 17,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -24546,7 +24601,7 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-03T01:43:35Z",
+          "updatedAt": "2020-05-12T02:02:22Z",
           "createdAt": "2018-02-22T14:41:35Z",
           "pushedAt": "2020-02-23T07:56:41Z",
           "forks": 33,
@@ -24568,9 +24623,9 @@
       },
       "npmPkg": "react-native-file-selector",
       "npm": {
-        "downloads": 264,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 270,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24619,9 +24674,9 @@
       },
       "npmPkg": "react-native-bottom-action-sheet",
       "npm": {
-        "downloads": 1873,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1935,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24670,9 +24725,9 @@
       },
       "npmPkg": "react-native-popover-menu",
       "npm": {
-        "downloads": 742,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 746,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24699,13 +24754,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-07T02:22:41Z",
+          "updatedAt": "2020-05-11T23:46:16Z",
           "createdAt": "2018-01-13T10:45:23Z",
           "pushedAt": "2020-02-21T11:20:52Z",
           "forks": 30,
           "issues": 13,
           "subscribers": 7,
-          "stars": 312
+          "stars": 313
         },
         "name": "react-native-shine-button",
         "fullName": "prscX/react-native-shine-button",
@@ -24721,9 +24776,9 @@
       },
       "npmPkg": "react-native-shine-button",
       "npm": {
-        "downloads": 52,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 51,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24772,9 +24827,9 @@
       },
       "npmPkg": "react-native-form-generator",
       "npm": {
-        "downloads": 198,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 207,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24827,9 +24882,9 @@
       },
       "npmPkg": "react-native-easy-toast",
       "npm": {
-        "downloads": 35659,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 36659,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -24875,9 +24930,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 78,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 82,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24931,9 +24986,9 @@
       },
       "npmPkg": "react-native-event-bridge",
       "npm": {
-        "downloads": 93,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 96,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -24982,9 +25037,9 @@
       },
       "npmPkg": "react-native-canvas",
       "npm": {
-        "downloads": 3749,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3835,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25033,9 +25088,9 @@
       },
       "npmPkg": "react-native-scales",
       "npm": {
-        "downloads": 5,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -25061,7 +25116,7 @@
           "createdAt": "2016-02-09T15:29:10Z",
           "pushedAt": "2020-02-16T10:55:18Z",
           "forks": 69,
-          "issues": 19,
+          "issues": 20,
           "subscribers": 4,
           "stars": 256
         },
@@ -25085,9 +25140,9 @@
       },
       "npmPkg": "react-native-android-sms-listener",
       "npm": {
-        "downloads": 2643,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2717,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25114,13 +25169,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T22:59:03Z",
+          "updatedAt": "2020-05-12T15:48:10Z",
           "createdAt": "2017-01-11T16:42:51Z",
           "pushedAt": "2020-02-14T17:05:51Z",
           "forks": 79,
           "issues": 36,
           "subscribers": 26,
-          "stars": 921
+          "stars": 922
         },
         "name": "react-native-create-bridge",
         "fullName": "peggyrayzis/react-native-create-bridge",
@@ -25144,9 +25199,9 @@
       },
       "npmPkg": "react-native-create-bridge",
       "npm": {
-        "downloads": 3867,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4081,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25194,9 +25249,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 7,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -25254,15 +25309,13 @@
       },
       "npmPkg": "react-native-redux",
       "npm": {
-        "downloads": 151,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 157,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
-      "score": 56,
-      "matchingScoreModifiers": [
-        "Recently updated"
-      ],
+      "score": 50,
+      "matchingScoreModifiers": [],
       "topicSearchString": " react react-hooks react-native react-redux reactjs redux redux-actions redux-persist redux-store redux-thunk"
     },
     {
@@ -25284,13 +25337,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-09T20:17:49Z",
+          "updatedAt": "2020-05-12T11:09:35Z",
           "createdAt": "2017-10-12T16:43:01Z",
           "pushedAt": "2020-02-09T19:23:28Z",
           "forks": 45,
           "issues": 15,
           "subscribers": 2,
-          "stars": 159
+          "stars": 160
         },
         "name": "react-native-file-viewer",
         "fullName": "vinzscam/react-native-file-viewer",
@@ -25299,9 +25352,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 31031,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 31838,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25358,9 +25411,9 @@
       },
       "npmPkg": "react-native-popup-menu",
       "npm": {
-        "downloads": 47046,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 48160,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -25410,9 +25463,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 60261,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 63124,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -25459,9 +25512,9 @@
       },
       "npmPkg": "react-native-read-more-text",
       "npm": {
-        "downloads": 29828,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 30610,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25517,9 +25570,9 @@
         }
       },
       "npm": {
-        "downloads": 34265,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 34786,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25574,9 +25627,9 @@
         }
       },
       "npm": {
-        "downloads": 55492,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 57458,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25637,9 +25690,9 @@
       },
       "npmPkg": "react-native-viewpager-carousel",
       "npm": {
-        "downloads": 416,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 425,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -25689,8 +25742,8 @@
       },
       "npm": {
         "downloads": 78,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -25739,9 +25792,9 @@
       },
       "npmPkg": "react-native-css",
       "npm": {
-        "downloads": 861,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 876,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25796,9 +25849,9 @@
         }
       },
       "npm": {
-        "downloads": 20252,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 20654,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25825,13 +25878,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T10:06:17Z",
+          "updatedAt": "2020-05-12T13:02:26Z",
           "createdAt": "2017-06-23T07:11:35Z",
           "pushedAt": "2020-01-22T08:41:44Z",
-          "forks": 138,
+          "forks": 139,
           "issues": 31,
           "subscribers": 22,
-          "stars": 498
+          "stars": 500
         },
         "name": "react-native-document-scanner",
         "fullName": "Michaelvilleneuve/react-native-document-scanner",
@@ -25852,9 +25905,9 @@
       },
       "npmPkg": "react-native-document-scanner",
       "npm": {
-        "downloads": 4009,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4094,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -25908,9 +25961,9 @@
       },
       "npmPkg": "react-native-hotspot",
       "npm": {
-        "downloads": 8,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 9,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -25959,9 +26012,9 @@
         }
       },
       "npm": {
-        "downloads": 3445,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3581,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -26013,9 +26066,9 @@
       },
       "npmPkg": "react-native-photo-browser",
       "npm": {
-        "downloads": 400,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 410,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -26063,9 +26116,9 @@
       },
       "npmPkg": "react-native-smaato-ad",
       "npm": {
-        "downloads": 17,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 18,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -26092,7 +26145,7 @@
           "updatedAt": "2020-05-11T12:24:45Z",
           "createdAt": "2015-03-28T18:06:13Z",
           "pushedAt": "2020-01-10T18:07:33Z",
-          "forks": 429,
+          "forks": 430,
           "issues": 119,
           "subscribers": 68,
           "stars": 3164
@@ -26111,9 +26164,9 @@
       },
       "npmPkg": "tcomb-form-native",
       "npm": {
-        "downloads": 20322,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 20881,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -26160,9 +26213,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 6248,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6427,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -26218,9 +26271,9 @@
       },
       "npmPkg": "react-native-hyperlink",
       "npm": {
-        "downloads": 78748,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 81273,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26281,9 +26334,9 @@
       },
       "npmPkg": "react-native-responsive-grid",
       "npm": {
-        "downloads": 2279,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2452,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26333,9 +26386,9 @@
       },
       "npmPkg": "react-native-circular-action-menu",
       "npm": {
-        "downloads": 1905,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1917,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26388,9 +26441,9 @@
       },
       "npmPkg": "react-native-fbads",
       "npm": {
-        "downloads": 679,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 706,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26444,9 +26497,9 @@
       },
       "npmPkg": "react-native-fbads",
       "npm": {
-        "downloads": 679,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 706,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26473,13 +26526,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T17:07:21Z",
+          "updatedAt": "2020-05-12T16:43:43Z",
           "createdAt": "2017-12-04T16:12:46Z",
           "pushedAt": "2020-01-04T15:19:00Z",
           "forks": 114,
           "issues": 13,
           "subscribers": 37,
-          "stars": 2999
+          "stars": 3000
         },
         "name": "react-native-typography",
         "fullName": "hectahertz/react-native-typography",
@@ -26502,9 +26555,9 @@
       },
       "npmPkg": "react-native-typography",
       "npm": {
-        "downloads": 21784,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 22648,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -26561,9 +26614,9 @@
       },
       "npmPkg": "react-native-cell-components",
       "npm": {
-        "downloads": 80,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 83,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26609,9 +26662,9 @@
       },
       "npmPkg": "react-native-webgl",
       "npm": {
-        "downloads": 169,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 174,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26665,9 +26718,9 @@
         }
       },
       "npm": {
-        "downloads": 3031,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3111,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26718,9 +26771,9 @@
         }
       },
       "npm": {
-        "downloads": 12673,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 13458,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26785,9 +26838,9 @@
       },
       "npmPkg": "react-reactive-form",
       "npm": {
-        "downloads": 6629,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6753,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -26854,73 +26907,14 @@
       },
       "npmPkg": "react-native-d3multiline-chart",
       "npm": {
-        "downloads": 115,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 114,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
       "matchingScoreModifiers": [],
       "topicSearchString": " android animation chart charts d3js d3v4 graph ios legend line line-graph multiline multiline-graph react-native-svg running-line-animation scatterpoint scatterpoint-graph"
-    },
-    {
-      "githubUrl": "https://github.com/evollu/react-native-fcm",
-      "ios": true,
-      "android": true,
-      "expo": false,
-      "github": {
-        "urls": {
-          "repo": "https://github.com/evollu/react-native-fcm",
-          "clone": "https://github.com/evollu/react-native-fcm.git",
-          "homepage": ""
-        },
-        "stats": {
-          "hasIssues": true,
-          "hasWiki": true,
-          "hasPages": false,
-          "hasDownloads": true,
-          "hasTopics": true,
-          "updatedAt": "2020-05-11T08:56:53Z",
-          "createdAt": "2016-05-29T03:53:22Z",
-          "pushedAt": "2019-12-28T17:49:43Z",
-          "forks": 708,
-          "issues": 297,
-          "subscribers": 42,
-          "stars": 1718
-        },
-        "name": "react-native-fcm",
-        "fullName": "evollu/react-native-fcm",
-        "description": "react native module for firebase cloud messaging and local notification",
-        "topics": [
-          "android",
-          "fcm",
-          "firebase",
-          "ios",
-          "local-notifications",
-          "notifications"
-        ],
-        "license": {
-          "key": "mit",
-          "name": "MIT License",
-          "spdx_id": "MIT",
-          "url": "https://api.github.com/licenses/mit",
-          "node_id": "MDc6TGljZW5zZTEz"
-        }
-      },
-      "npmPkg": "react-native-fcm",
-      "npm": {
-        "downloads": 12587,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
-        "period": "month"
-      },
-      "score": 50,
-      "matchingScoreModifiers": [
-        "Popular",
-        "Lots of open issues",
-        "Recently updated"
-      ],
-      "topicSearchString": " android fcm firebase ios local-notifications notifications"
     },
     {
       "githubUrl": "https://github.com/APSL/react-native-button",
@@ -26968,9 +26962,9 @@
         }
       },
       "npm": {
-        "downloads": 4068,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4237,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -27024,9 +27018,9 @@
         }
       },
       "npm": {
-        "downloads": 50657,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 53036,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -27081,9 +27075,9 @@
       },
       "npmPkg": "react-native-button-component",
       "npm": {
-        "downloads": 202,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 207,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -27137,9 +27131,9 @@
       },
       "npmPkg": "react-native-bottom-sheet-behavior",
       "npm": {
-        "downloads": 628,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 636,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -27168,13 +27162,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T13:02:54Z",
+          "updatedAt": "2020-05-12T11:44:42Z",
           "createdAt": "2017-03-31T07:36:13Z",
           "pushedAt": "2019-12-28T03:48:44Z",
           "forks": 138,
           "issues": 22,
           "subscribers": 11,
-          "stars": 992
+          "stars": 994
         },
         "name": "react-native-masonry",
         "fullName": "brh55/react-native-masonry",
@@ -27197,9 +27191,9 @@
         }
       },
       "npm": {
-        "downloads": 561,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 572,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -27245,9 +27239,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 674,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 692,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -27273,13 +27267,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T05:50:58Z",
+          "updatedAt": "2020-05-12T12:06:08Z",
           "createdAt": "2016-06-27T03:09:07Z",
           "pushedAt": "2019-12-27T21:17:00Z",
           "forks": 230,
           "issues": 9,
           "subscribers": 15,
-          "stars": 1426
+          "stars": 1428
         },
         "name": "react-native-dropdownalert",
         "fullName": "testshallpass/react-native-dropdownalert",
@@ -27300,9 +27294,9 @@
       },
       "npmPkg": "react-native-dropdownalert",
       "npm": {
-        "downloads": 41251,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 42173,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -27336,7 +27330,7 @@
           "updatedAt": "2020-05-10T16:25:17Z",
           "createdAt": "2016-04-12T08:56:36Z",
           "pushedAt": "2019-12-27T08:19:36Z",
-          "forks": 107,
+          "forks": 108,
           "issues": 34,
           "subscribers": 17,
           "stars": 358
@@ -27354,9 +27348,9 @@
         }
       },
       "npm": {
-        "downloads": 10548,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 10728,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -27404,9 +27398,9 @@
       },
       "npmPkg": "react-native-gifted-form",
       "npm": {
-        "downloads": 273,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 281,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -27435,13 +27429,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T14:12:44Z",
+          "updatedAt": "2020-05-12T17:01:17Z",
           "createdAt": "2016-04-10T00:44:42Z",
           "pushedAt": "2019-12-19T20:25:50Z",
           "forks": 128,
           "issues": 18,
-          "subscribers": 30,
-          "stars": 1801
+          "subscribers": 31,
+          "stars": 1802
         },
         "name": "apisauce",
         "fullName": "infinitered/apisauce",
@@ -27462,9 +27456,9 @@
         }
       },
       "npm": {
-        "downloads": 214767,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 223598,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -27514,9 +27508,9 @@
       },
       "npmPkg": "react-native-root-siblings",
       "npm": {
-        "downloads": 129610,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 133987,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -27544,13 +27538,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-10T05:05:43Z",
+          "updatedAt": "2020-05-12T04:38:11Z",
           "createdAt": "2015-07-16T12:22:46Z",
           "pushedAt": "2019-12-15T11:59:53Z",
           "forks": 179,
           "issues": 18,
           "subscribers": 31,
-          "stars": 1507
+          "stars": 1508
         },
         "name": "react-native-image-progress",
         "fullName": "oblador/react-native-image-progress",
@@ -27566,9 +27560,9 @@
       },
       "npmPkg": "react-native-image-progress",
       "npm": {
-        "downloads": 30277,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 31349,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -27622,9 +27616,9 @@
         }
       },
       "npm": {
-        "downloads": 1780,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1808,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -27676,9 +27670,9 @@
       },
       "npmPkg": "react-native-dns-lookup",
       "npm": {
-        "downloads": 18,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 20,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -27730,9 +27724,9 @@
       },
       "npmPkg": "react-native-gesture-password",
       "npm": {
-        "downloads": 397,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 406,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -27779,9 +27773,9 @@
       },
       "npmPkg": "react-native-drawer-layout",
       "npm": {
-        "downloads": 177405,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 183093,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -27834,9 +27828,9 @@
       },
       "npmPkg": "react-native-bottom-toolbar",
       "npm": {
-        "downloads": 1744,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1866,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -27869,7 +27863,7 @@
           "pushedAt": "2019-11-25T20:35:47Z",
           "forks": 180,
           "issues": 46,
-          "subscribers": 26,
+          "subscribers": 25,
           "stars": 992
         },
         "name": "react-native-timeline-listview",
@@ -27891,9 +27885,9 @@
         }
       },
       "npm": {
-        "downloads": 1591,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1665,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -27942,9 +27936,9 @@
       },
       "npmPkg": "react-native-carousel-control",
       "npm": {
-        "downloads": 1481,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1519,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -27972,13 +27966,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-09T14:02:58Z",
+          "updatedAt": "2020-05-12T12:34:43Z",
           "createdAt": "2015-09-26T13:52:58Z",
           "pushedAt": "2019-11-24T15:17:58Z",
           "forks": 78,
           "issues": 15,
           "subscribers": 15,
-          "stars": 821
+          "stars": 823
         },
         "name": "react-native-quick-actions",
         "fullName": "jordanbyron/react-native-quick-actions",
@@ -27993,9 +27987,9 @@
         }
       },
       "npm": {
-        "downloads": 23941,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 24525,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28048,9 +28042,9 @@
         }
       },
       "npm": {
-        "downloads": 41016,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 42169,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28108,9 +28102,9 @@
         }
       },
       "npm": {
-        "downloads": 9,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 10,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -28162,8 +28156,8 @@
       "npmPkg": "rn-verifcode",
       "npm": {
         "downloads": 3,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -28213,9 +28207,9 @@
       },
       "npmPkg": "react-native-image-marker",
       "npm": {
-        "downloads": 7879,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8347,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28268,9 +28262,9 @@
       },
       "npmPkg": "react-native-safe-image",
       "npm": {
-        "downloads": 15,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -28317,9 +28311,9 @@
       },
       "npmPkg": "react-native-sideswipe",
       "npm": {
-        "downloads": 17110,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 17745,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28362,9 +28356,9 @@
       },
       "npmPkg": "react-native-keyboard-aware-scrollview",
       "npm": {
-        "downloads": 28615,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 29602,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28417,9 +28411,9 @@
       },
       "npmPkg": "react-native-searchbar",
       "npm": {
-        "downloads": 1798,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1849,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28474,9 +28468,9 @@
       },
       "npmPkg": "react-native-nav",
       "npm": {
-        "downloads": 5668,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5833,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28529,9 +28523,9 @@
         }
       },
       "npm": {
-        "downloads": 12482,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 13011,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28579,9 +28573,9 @@
       },
       "npmPkg": "react-native-root-modal",
       "npm": {
-        "downloads": 4167,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4336,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28623,9 +28617,9 @@
       },
       "npmPkg": "react-native-device-monitor",
       "npm": {
-        "downloads": 8,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 9,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -28654,13 +28648,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-11T20:41:11Z",
+          "updatedAt": "2020-05-12T17:58:42Z",
           "createdAt": "2016-05-04T13:58:29Z",
           "pushedAt": "2019-11-02T01:07:08Z",
           "forks": 153,
           "issues": 23,
           "subscribers": 28,
-          "stars": 1848
+          "stars": 1849
         },
         "name": "react-native-easy-grid",
         "fullName": "GeekyAnts/react-native-easy-grid",
@@ -28676,9 +28670,9 @@
       },
       "npmPkg": "react-native-easy-grid",
       "npm": {
-        "downloads": 177447,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 181974,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -28705,13 +28699,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-05-09T13:22:45Z",
+          "updatedAt": "2020-05-12T03:40:46Z",
           "createdAt": "2017-01-19T20:29:28Z",
           "pushedAt": "2019-11-01T23:23:56Z",
           "forks": 72,
           "issues": 32,
           "subscribers": 10,
-          "stars": 605
+          "stars": 606
         },
         "name": "react-native-image-header-scroll-view",
         "fullName": "bamlab/react-native-image-header-scroll-view",
@@ -28727,9 +28721,9 @@
       },
       "npmPkg": "react-native-image-header-scroll-view",
       "npm": {
-        "downloads": 8873,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 9337,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28775,9 +28769,9 @@
       },
       "npmPkg": "react-native-tooltip",
       "npm": {
-        "downloads": 444,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 450,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28832,9 +28826,9 @@
       },
       "npmPkg": "react-native-simple-markdown",
       "npm": {
-        "downloads": 59945,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 62204,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28885,9 +28879,9 @@
       },
       "npmPkg": "react-native-swipeout",
       "npm": {
-        "downloads": 164235,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 168885,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 75,
@@ -28918,13 +28912,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-08T11:17:43Z",
+          "updatedAt": "2020-05-12T12:50:59Z",
           "createdAt": "2017-02-17T23:07:27Z",
           "pushedAt": "2019-10-29T12:36:44Z",
           "forks": 93,
           "issues": 61,
           "subscribers": 15,
-          "stars": 756
+          "stars": 758
         },
         "name": "react-native-background-task",
         "fullName": "jamesisaac/react-native-background-task",
@@ -28947,9 +28941,9 @@
         }
       },
       "npm": {
-        "downloads": 3480,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3582,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -28998,9 +28992,9 @@
         }
       },
       "npm": {
-        "downloads": 40988,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 42327,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -29053,9 +29047,9 @@
       },
       "npmPkg": "react-native-suggester",
       "npm": {
-        "downloads": 23,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 24,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29102,9 +29096,9 @@
       },
       "npmPkg": "react-native-photo-view",
       "npm": {
-        "downloads": 4016,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4197,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -29160,9 +29154,9 @@
       },
       "npmPkg": "react-native-indicators",
       "npm": {
-        "downloads": 46858,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 48150,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29217,9 +29211,9 @@
       },
       "npmPkg": "react-native-network-info",
       "npm": {
-        "downloads": 16201,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16787,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29244,13 +29238,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-02-23T21:16:48Z",
+          "updatedAt": "2020-05-12T14:53:31Z",
           "createdAt": "2016-08-15T06:13:12Z",
           "pushedAt": "2019-10-14T16:12:02Z",
           "forks": 100,
           "issues": 61,
           "subscribers": 13,
-          "stars": 485
+          "stars": 486
         },
         "name": "react-native-smart-splash-screen",
         "fullName": "react-native-component/react-native-smart-splash-screen",
@@ -29266,13 +29260,15 @@
       },
       "npmPkg": "react-native-smart-splash-screen",
       "npm": {
-        "downloads": 1845,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1956,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
-      "score": 50,
-      "matchingScoreModifiers": [],
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
       "topicSearchString": ""
     },
     {
@@ -29323,9 +29319,9 @@
       },
       "npmPkg": "react-native-photo-upload",
       "npm": {
-        "downloads": 3033,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3058,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29373,9 +29369,9 @@
         }
       },
       "npm": {
-        "downloads": 2832,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2950,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29429,9 +29425,9 @@
       },
       "npmPkg": "react-native-proximity",
       "npm": {
-        "downloads": 136,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 128,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29479,9 +29475,9 @@
       },
       "npmPkg": "react-native-lazyload",
       "npm": {
-        "downloads": 881,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 887,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29523,9 +29519,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 489,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 511,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -29578,9 +29574,9 @@
       },
       "npmPkg": "react-native-keyboard-accessory",
       "npm": {
-        "downloads": 15443,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16118,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29622,9 +29618,9 @@
       },
       "npmPkg": "react-native-svg-uri",
       "npm": {
-        "downloads": 25083,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 25925,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -29669,9 +29665,9 @@
       },
       "npmPkg": "react-native-apple-ads-attribution",
       "npm": {
-        "downloads": 199,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 211,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -29722,9 +29718,9 @@
       },
       "npmPkg": "react-native-clean-form",
       "npm": {
-        "downloads": 1378,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1405,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29772,9 +29768,9 @@
       },
       "npmPkg": "react-native-google-play-game-services",
       "npm": {
-        "downloads": 13,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -29829,9 +29825,9 @@
       },
       "npmPkg": "react-native-circular-slider",
       "npm": {
-        "downloads": 335,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 339,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -29884,9 +29880,9 @@
         }
       },
       "npm": {
-        "downloads": 2795,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2849,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -29928,9 +29924,9 @@
       },
       "npmPkg": "react-native-viewpager",
       "npm": {
-        "downloads": 4808,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4922,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -29987,9 +29983,9 @@
         }
       },
       "npm": {
-        "downloads": 95268,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 98708,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -30014,13 +30010,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-04-28T17:21:58Z",
+          "updatedAt": "2020-05-12T02:45:57Z",
           "createdAt": "2015-12-22T22:05:40Z",
           "pushedAt": "2019-09-09T17:33:53Z",
           "forks": 104,
           "issues": 14,
           "subscribers": 6,
-          "stars": 357
+          "stars": 356
         },
         "name": "react-native-extra-dimensions-android",
         "fullName": "Sunhat/react-native-extra-dimensions-android",
@@ -30036,9 +30032,9 @@
       },
       "npmPkg": "react-native-extra-dimensions-android",
       "npm": {
-        "downloads": 22920,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 23655,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30081,8 +30077,8 @@
       "npmPkg": "cairn",
       "npm": {
         "downloads": 16,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30130,9 +30126,9 @@
       },
       "npmPkg": "react-native-keep-awake",
       "npm": {
-        "downloads": 74688,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 77070,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -30187,9 +30183,9 @@
       },
       "npmPkg": "react-native-social-share",
       "npm": {
-        "downloads": 828,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 835,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30238,9 +30234,9 @@
         }
       },
       "npm": {
-        "downloads": 206,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 213,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30289,9 +30285,9 @@
         }
       },
       "npm": {
-        "downloads": 41019,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 42312,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30340,9 +30336,9 @@
         }
       },
       "npm": {
-        "downloads": 115529,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 118898,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -30391,9 +30387,9 @@
       },
       "npmPkg": "react-native-invertible-scroll-view",
       "npm": {
-        "downloads": 19027,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 19715,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30442,9 +30438,9 @@
       },
       "npmPkg": "react-native-keyguard",
       "npm": {
-        "downloads": 5,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -30491,9 +30487,9 @@
       },
       "npmPkg": "react-native-geocoder",
       "npm": {
-        "downloads": 22745,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 23695,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30519,7 +30515,7 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-08T03:39:25Z",
+          "updatedAt": "2020-05-12T03:28:19Z",
           "createdAt": "2017-01-30T14:22:09Z",
           "pushedAt": "2019-06-28T13:28:00Z",
           "forks": 129,
@@ -30547,9 +30543,9 @@
       },
       "npmPkg": "nachos-ui",
       "npm": {
-        "downloads": 444,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 445,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -30604,9 +30600,9 @@
       },
       "npmPkg": "native-navigation",
       "npm": {
-        "downloads": 36,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 34,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -30661,9 +30657,9 @@
       },
       "npmPkg": "react-native-version-info",
       "npm": {
-        "downloads": 9753,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 9833,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -30716,9 +30712,9 @@
         }
       },
       "npm": {
-        "downloads": 204,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 206,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30775,8 +30771,8 @@
       "npmPkg": "react-native-simple-router",
       "npm": {
         "downloads": 40,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30824,9 +30820,9 @@
       },
       "npmPkg": "react-native-settings-list",
       "npm": {
-        "downloads": 2769,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2802,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -30871,9 +30867,9 @@
       },
       "npmPkg": "react-native-text-avatar",
       "npm": {
-        "downloads": 423,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 456,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -30917,9 +30913,9 @@
       },
       "npmPkg": "react-native-draggable-calendar",
       "npm": {
-        "downloads": 120,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 122,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -30968,9 +30964,9 @@
       },
       "npmPkg": "react-native-emoji",
       "npm": {
-        "downloads": 9404,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 9653,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -31020,9 +31016,9 @@
       },
       "npmPkg": "rn-splash-screen",
       "npm": {
-        "downloads": 1755,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1792,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -31065,9 +31061,9 @@
       },
       "npmPkg": "react-native-super-image",
       "npm": {
-        "downloads": 15,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -31112,9 +31108,9 @@
       },
       "npmPkg": "mrn",
       "npm": {
-        "downloads": 26,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 27,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -31142,13 +31138,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-04-09T00:33:02Z",
+          "updatedAt": "2020-05-12T06:05:13Z",
           "createdAt": "2017-03-06T19:56:08Z",
           "pushedAt": "2019-05-14T10:41:07Z",
           "forks": 52,
           "issues": 9,
-          "subscribers": 28,
-          "stars": 331
+          "subscribers": 27,
+          "stars": 332
         },
         "name": "react-native-draftjs-render",
         "fullName": "globocom/react-native-draftjs-render",
@@ -31168,13 +31164,15 @@
         }
       },
       "npm": {
-        "downloads": 2139,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2198,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
-      "score": 50,
-      "matchingScoreModifiers": [],
+      "score": 56,
+      "matchingScoreModifiers": [
+        "Recently updated"
+      ],
       "topicSearchString": " draft-js draftjs react-native reactnative"
     },
     {
@@ -31217,9 +31215,9 @@
       },
       "npmPkg": "react-native-tips",
       "npm": {
-        "downloads": 561,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 593,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -31245,13 +31243,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-09T11:23:17Z",
+          "updatedAt": "2020-05-12T10:29:45Z",
           "createdAt": "2017-01-09T03:32:10Z",
           "pushedAt": "2019-04-29T10:32:37Z",
           "forks": 62,
           "issues": 24,
           "subscribers": 10,
-          "stars": 254
+          "stars": 255
         },
         "name": "react-native-mentions",
         "fullName": "harshq/react-native-mentions",
@@ -31276,9 +31274,9 @@
       },
       "npmPkg": "react-native-mentions",
       "npm": {
-        "downloads": 1353,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1395,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -31321,9 +31319,9 @@
       },
       "npmPkg": "react-native-popover",
       "npm": {
-        "downloads": 473,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 533,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -31378,9 +31376,9 @@
       },
       "npmPkg": "react-native-fa-icons",
       "npm": {
-        "downloads": 455,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 457,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -31425,9 +31423,9 @@
       },
       "npmPkg": "react-native-fade-in-image",
       "npm": {
-        "downloads": 5391,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5544,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -31479,9 +31477,9 @@
       },
       "npmPkg": "react-native-buglife",
       "npm": {
-        "downloads": 22,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 23,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -31529,9 +31527,9 @@
       },
       "npmPkg": "react-native-console-panel",
       "npm": {
-        "downloads": 15,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 17,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -31580,8 +31578,8 @@
       "npmPkg": "react-native-units",
       "npm": {
         "downloads": 13,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -31640,9 +31638,9 @@
       },
       "npmPkg": "rn-option-select",
       "npm": {
-        "downloads": 19,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 20,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -31685,9 +31683,9 @@
       },
       "npmPkg": "react-native-columns",
       "npm": {
-        "downloads": 9,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 10,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -31740,9 +31738,9 @@
         }
       },
       "npm": {
-        "downloads": 15657,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 16182,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -31785,9 +31783,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 12117,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 12553,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -31836,9 +31834,9 @@
         }
       },
       "npm": {
-        "downloads": 60,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 83,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -31896,9 +31894,9 @@
       },
       "npmPkg": "react-native-style-tachyons",
       "npm": {
-        "downloads": 6576,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6562,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -31941,9 +31939,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 203,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 201,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -32003,9 +32001,9 @@
       },
       "npmPkg": "react-native-directed-scrollview",
       "npm": {
-        "downloads": 355,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 356,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32052,9 +32050,9 @@
       },
       "npmPkg": "react-native-pdf-view",
       "npm": {
-        "downloads": 342,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 359,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32103,9 +32101,9 @@
       },
       "npmPkg": "react-native-scrolling-images",
       "npm": {
-        "downloads": 30,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 31,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -32152,9 +32150,9 @@
         }
       },
       "npm": {
-        "downloads": 950,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 996,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -32201,9 +32199,9 @@
       },
       "npmPkg": "react-native-material-design",
       "npm": {
-        "downloads": 1665,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1700,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -32252,9 +32250,9 @@
       },
       "npmPkg": "react-native-toast",
       "npm": {
-        "downloads": 84,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 91,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -32307,9 +32305,9 @@
       },
       "npmPkg": "react-native-app-intro",
       "npm": {
-        "downloads": 615,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 614,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -32360,9 +32358,9 @@
       },
       "npmPkg": "react-native-custom-action-sheet",
       "npm": {
-        "downloads": 163,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 166,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32405,9 +32403,9 @@
       },
       "npmPkg": "react-imation",
       "npm": {
-        "downloads": 201,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 207,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32450,9 +32448,9 @@
       },
       "npmPkg": "react-native-accordion",
       "npm": {
-        "downloads": 522,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 523,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32500,9 +32498,9 @@
       },
       "npmPkg": "react-native-emoji-picker",
       "npm": {
-        "downloads": 20,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 23,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32544,9 +32542,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 957,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 955,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -32592,9 +32590,9 @@
       },
       "npmPkg": "react-native-fence-html",
       "npm": {
-        "downloads": 22,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 23,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -32635,9 +32633,9 @@
       },
       "npmPkg": "react-native-md-textinput",
       "npm": {
-        "downloads": 234,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 240,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32690,9 +32688,9 @@
       },
       "npmPkg": "react-native-modal-popover",
       "npm": {
-        "downloads": 14069,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14611,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32734,9 +32732,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 680,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 717,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -32785,9 +32783,9 @@
       },
       "npmPkg": "react-native-linkedin-login",
       "npm": {
-        "downloads": 42,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 49,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32829,9 +32827,9 @@
       },
       "npmPkg": "react-native-popup",
       "npm": {
-        "downloads": 42,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 46,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32874,8 +32872,8 @@
       "npmPkg": "rn-displayable",
       "npm": {
         "downloads": 10,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -32927,9 +32925,9 @@
       },
       "npmPkg": "react-native-device-display",
       "npm": {
-        "downloads": 26,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 27,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -32978,9 +32976,9 @@
       },
       "npmPkg": "react-native-bouncy-drawer",
       "npm": {
-        "downloads": 27,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 31,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -33028,9 +33026,9 @@
         }
       },
       "npm": {
-        "downloads": 759,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 766,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -33080,9 +33078,9 @@
       },
       "npmPkg": "react-native-db-models",
       "npm": {
-        "downloads": 672,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 707,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -33129,9 +33127,9 @@
       },
       "npmPkg": "react-native-infinite-scroll-view",
       "npm": {
-        "downloads": 8208,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8452,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -33189,9 +33187,9 @@
       },
       "npmPkg": "react-native-pseudo-localization",
       "npm": {
-        "downloads": 939,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 914,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -33238,9 +33236,9 @@
       },
       "npmPkg": "react-native-about-libraries",
       "npm": {
-        "downloads": 761,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 763,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -33294,9 +33292,9 @@
       },
       "npmPkg": "react-native-localizable",
       "npm": {
-        "downloads": 8,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 9,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -33345,9 +33343,9 @@
       },
       "npmPkg": "react-native-gradient-blur-view",
       "npm": {
-        "downloads": 6,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -33394,9 +33392,9 @@
       },
       "npmPkg": "react-native-material-shadows",
       "npm": {
-        "downloads": 11,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -33443,9 +33441,9 @@
       },
       "npmPkg": "react-native-morphing-text",
       "npm": {
-        "downloads": 40,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 42,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -33495,8 +33493,8 @@
       "npmPkg": "react-native-spruce",
       "npm": {
         "downloads": 50,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -33549,9 +33547,9 @@
       },
       "npmPkg": "react-native-mirror",
       "npm": {
-        "downloads": 392,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 401,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -33593,9 +33591,9 @@
       },
       "npmPkg": "react-native-menu",
       "npm": {
-        "downloads": 3191,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3298,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -33644,9 +33642,9 @@
       },
       "npmPkg": "react-native-foldview",
       "npm": {
-        "downloads": 315,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 323,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -33699,9 +33697,9 @@
         }
       },
       "npm": {
-        "downloads": 33,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 34,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 44,
@@ -33756,9 +33754,9 @@
       },
       "npmPkg": "react-native-material-palette",
       "npm": {
-        "downloads": 12,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 14,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -33806,9 +33804,9 @@
         }
       },
       "npm": {
-        "downloads": 2288,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2312,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -33857,9 +33855,9 @@
       },
       "npmPkg": "react-native-gifted-listview",
       "npm": {
-        "downloads": 114,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 119,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -33887,13 +33885,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": true,
-          "updatedAt": "2020-05-11T04:38:48Z",
+          "updatedAt": "2020-05-12T02:32:16Z",
           "createdAt": "2015-10-12T23:29:34Z",
           "pushedAt": "2018-06-21T00:11:14Z",
           "forks": 177,
           "issues": 30,
           "subscribers": 14,
-          "stars": 1370
+          "stars": 1371
         },
         "name": "react-native-keyboard-spacer",
         "fullName": "Andr3wHur5t/react-native-keyboard-spacer",
@@ -33915,9 +33913,9 @@
       },
       "npmPkg": "react-native-keyboard-spacer",
       "npm": {
-        "downloads": 81633,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 83939,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -33967,9 +33965,9 @@
       },
       "npmPkg": "react-native-falling-drawer",
       "npm": {
-        "downloads": 16,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 17,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34019,9 +34017,9 @@
       },
       "npmPkg": "react-native-simple-modal",
       "npm": {
-        "downloads": 947,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 961,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34046,13 +34044,13 @@
           "hasPages": false,
           "hasDownloads": true,
           "hasTopics": false,
-          "updatedAt": "2020-04-29T13:12:10Z",
+          "updatedAt": "2020-05-12T01:51:00Z",
           "createdAt": "2018-03-12T14:27:35Z",
           "pushedAt": "2018-05-22T08:08:30Z",
           "forks": 5,
           "issues": 1,
           "subscribers": 1,
-          "stars": 18
+          "stars": 19
         },
         "name": "react-native-popup-menu-android",
         "fullName": "Noitidart/react-native-popup-menu-android",
@@ -34062,9 +34060,9 @@
       },
       "npmPkg": "react-native-popup-menu-android",
       "npm": {
-        "downloads": 1137,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1156,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -34113,8 +34111,8 @@
       "npmPkg": "react-native-buttonex",
       "npm": {
         "downloads": 28,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -34160,9 +34158,9 @@
       },
       "npmPkg": "react-native-image-zoom",
       "npm": {
-        "downloads": 612,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 635,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34214,9 +34212,9 @@
       },
       "npmPkg": "react-native-radio-buttons",
       "npm": {
-        "downloads": 7067,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 7259,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -34265,9 +34263,9 @@
       },
       "npmPkg": "react-native-animated-ptr",
       "npm": {
-        "downloads": 7,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34314,9 +34312,9 @@
       },
       "npmPkg": "react-native-google-analytics",
       "npm": {
-        "downloads": 3426,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 3561,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -34372,8 +34370,8 @@
       "npmPkg": "material-native",
       "npm": {
         "downloads": 3,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34426,9 +34424,9 @@
       },
       "npmPkg": "react-native-universal-picker",
       "npm": {
-        "downloads": 642,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 676,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -34471,9 +34469,9 @@
       },
       "npmPkg": "react-native-gallery",
       "npm": {
-        "downloads": 329,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 330,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34520,9 +34518,9 @@
       },
       "npmPkg": "react-native-material-showcase-ios",
       "npm": {
-        "downloads": 31,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 32,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34569,9 +34567,9 @@
       },
       "npmPkg": "react-native-taptargetview",
       "npm": {
-        "downloads": 19,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 20,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34617,9 +34615,9 @@
       },
       "npmPkg": "react-native-awesome-button",
       "npm": {
-        "downloads": 98,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 99,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -34671,9 +34669,9 @@
       },
       "npmPkg": "react-native-chooser",
       "npm": {
-        "downloads": 1119,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1154,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -34715,8 +34713,8 @@
       "npmPkg": "react-native-effects-view",
       "npm": {
         "downloads": 34,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -34759,9 +34757,9 @@
       },
       "npmPkg": "react-native-shake-event",
       "npm": {
-        "downloads": 301,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 319,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -34822,9 +34820,9 @@
       },
       "npmPkg": "react-native-pathjs-charts",
       "npm": {
-        "downloads": 574,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 587,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34874,9 +34872,9 @@
       },
       "npmPkg": "react-native-listitem",
       "npm": {
-        "downloads": 36,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 37,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -34922,9 +34920,9 @@
       },
       "npmPkg": "react-native-link",
       "npm": {
-        "downloads": 550,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 579,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -34967,9 +34965,9 @@
       },
       "npmPkg": "react-native-ab",
       "npm": {
-        "downloads": 23,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 26,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -35018,9 +35016,9 @@
       },
       "npmPkg": "react-native-offscreen-toolbar",
       "npm": {
-        "downloads": 18,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 19,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -35065,9 +35063,9 @@
       },
       "npmPkg": "react-native-face-pile",
       "npm": {
-        "downloads": 650,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 670,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -35122,9 +35120,9 @@
         }
       },
       "npm": {
-        "downloads": 205,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 217,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -35178,9 +35176,9 @@
       },
       "npmPkg": "react-native-loading-placeholder",
       "npm": {
-        "downloads": 2490,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2623,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -35228,9 +35226,9 @@
       },
       "npmPkg": "react-native-segment-io-analytics",
       "npm": {
-        "downloads": 7,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 8,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -35259,7 +35257,7 @@
           "updatedAt": "2020-04-21T02:34:41Z",
           "createdAt": "2015-05-18T21:05:16Z",
           "pushedAt": "2017-12-27T00:01:40Z",
-          "forks": 258,
+          "forks": 257,
           "issues": 44,
           "subscribers": 18,
           "stars": 552
@@ -35278,9 +35276,9 @@
       },
       "npmPkg": "react-native-calendar",
       "npm": {
-        "downloads": 1239,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1271,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -35324,9 +35322,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 2776,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 2884,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -35372,9 +35370,9 @@
       },
       "npmPkg": "react-native-stateless-form",
       "npm": {
-        "downloads": 47,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 48,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -35422,9 +35420,9 @@
       },
       "npmPkg": "react-native-tabs",
       "npm": {
-        "downloads": 15660,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 15790,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -35471,9 +35469,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 49,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 71,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -35512,9 +35510,9 @@
       },
       "npmPkg": "rn-nodeify",
       "npm": {
-        "downloads": 18972,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 19629,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -35561,9 +35559,9 @@
       },
       "npmPkg": "react-native-smart-badge",
       "npm": {
-        "downloads": 62,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 60,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -35610,9 +35608,9 @@
       },
       "npmPkg": "react-native-parallax",
       "npm": {
-        "downloads": 1036,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 1041,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -35668,9 +35666,9 @@
       },
       "npmPkg": "react-native-submit-button",
       "npm": {
-        "downloads": 26,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 27,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -35719,9 +35717,9 @@
       },
       "npmPkg": "react-native-parallax-view",
       "npm": {
-        "downloads": 299,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 310,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -35752,7 +35750,7 @@
           "pushedAt": "2017-11-15T19:35:20Z",
           "forks": 42,
           "issues": 7,
-          "subscribers": 317,
+          "subscribers": 316,
           "stars": 225
         },
         "name": "react-native-wordpress-editor",
@@ -35769,9 +35767,9 @@
       },
       "npmPkg": "react-native-wordpress-editor",
       "npm": {
-        "downloads": 77,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 79,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 63,
@@ -35815,8 +35813,8 @@
       "npmPkg": "rn-render-perfs",
       "npm": {
         "downloads": 3,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -35859,9 +35857,9 @@
       },
       "npmPkg": "react-native-progress-hud",
       "npm": {
-        "downloads": 80,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 82,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -35914,9 +35912,9 @@
       },
       "npmPkg": "react-native-ios-drag-drop",
       "npm": {
-        "downloads": 22,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 23,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -35962,9 +35960,9 @@
       },
       "npmPkg": "react-native-message-bar",
       "npm": {
-        "downloads": 4474,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4464,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -36007,9 +36005,9 @@
       },
       "npmPkg": "react-native-gestures",
       "npm": {
-        "downloads": 363,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 376,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36054,9 +36052,9 @@
       },
       "npmPkg": "react-native-asyncstorage",
       "npm": {
-        "downloads": 53,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 55,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -36104,9 +36102,9 @@
       },
       "npmPkg": "react-native-android-statusbar",
       "npm": {
-        "downloads": 84,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 83,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36147,9 +36145,9 @@
       },
       "npmPkg": "react-native-htmltext",
       "npm": {
-        "downloads": 103,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 106,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36196,9 +36194,9 @@
         }
       },
       "npm": {
-        "downloads": 78,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 84,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36244,9 +36242,9 @@
       },
       "npmPkg": "react-native-social-auth",
       "npm": {
-        "downloads": 30,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 31,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -36294,9 +36292,9 @@
       },
       "npmPkg": "react-native-orientation-listener",
       "npm": {
-        "downloads": 103,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 106,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36340,9 +36338,9 @@
       },
       "npmPkg": "react-native-stripe",
       "npm": {
-        "downloads": 96,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 101,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -36384,9 +36382,9 @@
       },
       "npmPkg": "react-native-speech",
       "npm": {
-        "downloads": 125,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 122,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -36428,9 +36426,9 @@
       },
       "npmPkg": "react-native-loading-container",
       "npm": {
-        "downloads": 33,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 34,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -36478,9 +36476,9 @@
       },
       "npmPkg": "react-native-tabbar",
       "npm": {
-        "downloads": 33,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 34,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -36528,9 +36526,9 @@
       },
       "npmPkg": "react-native-conductor",
       "npm": {
-        "downloads": 11,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 12,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36577,9 +36575,9 @@
         }
       },
       "npm": {
-        "downloads": 12524,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 12983,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36625,9 +36623,9 @@
       },
       "npmPkg": "react-native-slowlog",
       "npm": {
-        "downloads": 4374,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4522,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36672,9 +36670,9 @@
       },
       "npmPkg": "react-native-digits",
       "npm": {
-        "downloads": 10,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 11,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -36717,9 +36715,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 5257,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 5331,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36758,9 +36756,9 @@
       },
       "npmPkg": "react-native-android-tablayout",
       "npm": {
-        "downloads": 52,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 54,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36807,9 +36805,9 @@
       },
       "npmPkg": "react-native-markdown",
       "npm": {
-        "downloads": 42,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 43,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36855,9 +36853,9 @@
         }
       },
       "npm": {
-        "downloads": 45,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 47,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36905,8 +36903,8 @@
       "npmPkg": "react-native-webbrowser",
       "npm": {
         "downloads": 43,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -36948,9 +36946,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 5,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -36998,8 +36996,8 @@
       },
       "npm": {
         "downloads": 32,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -37041,9 +37039,9 @@
       },
       "npmPkg": "react-native-card-io",
       "npm": {
-        "downloads": 18,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 19,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 56,
@@ -37086,9 +37084,9 @@
       },
       "npmPkg": "react-native-navigation-drawer",
       "npm": {
-        "downloads": 39,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 40,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -37129,9 +37127,9 @@
       },
       "npmPkg": "react-native-custom-navigation",
       "npm": {
-        "downloads": 12,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 13,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -37170,9 +37168,9 @@
         "license": null
       },
       "npm": {
-        "downloads": 5,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 6,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -37221,9 +37219,9 @@
       },
       "npmPkg": "react-native-switcher",
       "npm": {
-        "downloads": 3,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 4,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 38,
@@ -37271,9 +37269,9 @@
         }
       },
       "npm": {
-        "downloads": 9,
-        "start": "2020-04-11",
-        "end": "2020-05-10",
+        "downloads": 10,
+        "start": "2020-04-12",
+        "end": "2020-05-11",
         "period": "month"
       },
       "score": 50,
@@ -37285,7 +37283,7 @@
     "gl-react": 1,
     "gl-react-native": 1,
     "image-filters": 1,
-    "react-native": 394,
+    "react-native": 393,
     "icons": 2,
     "react-native-icons": 1,
     "unicons": 1,
@@ -38085,9 +38083,9 @@
     "iap": 1,
     "purchases": 1,
     "checkbox": 2,
-    "googleauth": 2,
-    "googlesignin": 2,
-    "oauth2": 3,
+    "googleauth": 1,
+    "googlesignin": 1,
+    "oauth2": 2,
     "amazon-cognito": 1,
     "aws": 1,
     "aws-apigateway": 1,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5027,5 +5027,19 @@
     "windows": false,
     "npmPkg": "react-native-material-backdrop-modal",
     "unmaintained": false
+  },
+  {
+    "githubUrl": "https://github.com/christianjuth/react-context-theming",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expo": true,
+    "windows": false,
+    "examples": [
+      "https://github.com/christianjuth/react-context-theming/tree/master/examples/expo",
+      "https://github.com/christianjuth/react-context-theming/tree/master/examples/cra"
+    ],
+    "npmPkg": "https://www.npmjs.com/package/react-context-theming",
+    "unmaintained": false
   }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

<!--
Does this PR add a feature? Address a bug? Add a new library?

Document your changes here.
-->

Add react-context-theming library. 

#### Brief Description:
The purpose of this library is to provide one API that allows you to dynamically theme both React Native Apps (including RN Web) and React.js. The library is inspired by what I've seen from React Native Paper and Material UI, but decoupled from a library of components. This library is still a work in progress, but there are two RN apps that I know of that are using this library in production (full disclosure one of those apps belongs to a company I work for).

# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

If you added a new library:

- [x] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
