### PR TITLE
add web support for react-native-msal

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4363,8 +4363,10 @@
   },
   {
     "githubUrl": "https://github.com/stashenergy/react-native-msal",
+    "npmPkg": "react-native-msal",
     "ios": true,
     "android": true,
+    "web": true,
     "examples": ["https://github.com/stashenergy/react-native-msal/tree/master/example"]
   },
   {

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4363,7 +4363,6 @@
   },
   {
     "githubUrl": "https://github.com/stashenergy/react-native-msal",
-    "npmPkg": "react-native-msal",
     "ios": true,
     "android": true,
     "web": true,


### PR DESCRIPTION
# Why

We've recently added web support to our package, although it's still in beta.
I also added the NPM package name
