### PR TITLE
docs: update url for segmented-control

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3024,7 +3024,7 @@
     "npmPkg": "@react-native-community/clipboard"
   },
   {
-    "githubUrl": "https://github.com/react-native-community/segmented-control",
+    "githubUrl": "https://github.com/react-native-segmented-control/segmented-control",
     "images": [
       "https://user-images.githubusercontent.com/6936373/71608757-dc6ef680-2bc6-11ea-85be-aa31f25ecf36.png",
       "https://user-images.githubusercontent.com/6936373/79550655-9edd9d00-80d3-11ea-98bf-8b7c0b0798d3.png",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

segmented-control component moved from react-native-community to its own org, react-native-segmented-control.

I've changed the url to the updated url.

I'll update the npm package when it's published in the updated npm org