### PR TITLE
add react-native-week-view library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5315,5 +5315,16 @@
     ],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/hoangnm/react-native-week-view",
+    "examples": [
+      "https://github.com/hoangnm/react-native-week-view/tree/master/example"
+    ],
+    "images": [
+      "https://github.com/hoangnm/react-native-week-view/raw/master/images/gif.gif"
+    ],
+    "ios": true,
+    "android": true    
   }
 ]


### PR DESCRIPTION
# Why

This PR adds [`react-native-week-view`](https://github.com/hoangnm/react-native-week-view) library to the directory.

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**
