### PR TITLE
improve mobile styling, fix react warning

### DIFF
--- a/components/CompatibilityTags.tsx
+++ b/components/CompatibilityTags.tsx
@@ -67,6 +67,7 @@ export function CompatibilityTags(props: Props) {
           {platforms.map(platform => (
             <Tag
               platform={platform}
+              key={`${platform}-platform`}
               tagStyle={{
                 backgroundColor: context.isDark ? darkColors.dark : colors.gray1,
                 borderColor: context.isDark ? darkColors.border : colors.gray2,

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -147,7 +147,8 @@ const styles = StyleSheet.create({
   },
   footerText: {
     textAlign: 'center',
-    padding: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 20,
     fontSize: 13,
   },
   platformsWrapper: {

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -59,7 +59,7 @@ export default function Library(props: Props) {
                 </View>
               </View>
             ) : null}
-            <View style={styles.displayHorizontal}>
+            <View style={isSmallScreen ? styles.containerColumn : styles.displayHorizontal}>
               <A
                 href={library.githubUrl || github.urls.repo}
                 style={styles.name}
@@ -69,8 +69,8 @@ export default function Library(props: Props) {
               {library.goldstar && (
                 <View
                   style={[
-                    styles.displayHorizontal,
                     styles.recommendedContainer,
+                    isSmallScreen ? styles.recommendedContainerSmall : null,
                     {
                       backgroundColor: context.isDark ? colors.primaryDark : colors.primaryLight,
                     },
@@ -113,8 +113,8 @@ export default function Library(props: Props) {
             github.urls.homepage ||
             (library.examples && library.examples.length) ? (
               <>
-                <View style={styles.filler} />
-                <View style={styles.bottomBar}>
+                {isSmallScreen ? null : <View style={styles.filler} />}
+                <View style={[styles.bottomBar, isSmallScreen ? styles.bottomBarSmall : {}]}>
                   <View style={[styles.displayHorizontal, styles.secondaryStats]}>
                     <MetaData library={library} secondary />
                   </View>
@@ -200,6 +200,11 @@ let styles = StyleSheet.create({
     marginLeft: 10,
     top: 1,
   },
+  recommendedContainerSmall: {
+    marginLeft: 0,
+    marginTop: 8,
+    alignSelf: 'flex-start',
+  },
   recommendedTextContainer: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -232,7 +237,7 @@ let styles = StyleSheet.create({
     marginTop: 12,
   },
   secondaryStats: {
-    marginTop: 6,
+    marginVertical: 6,
     flexWrap: 'wrap',
   },
   secondaryText: {
@@ -247,6 +252,14 @@ let styles = StyleSheet.create({
     minHeight: 42,
     paddingLeft: 20,
     paddingRight: 16,
+  },
+  bottomBarSmall: {
+    position: 'relative',
+    minHeight: 'auto',
+    paddingLeft: 0,
+    paddingRight: 0,
+    marginTop: 6,
+    marginBottom: -4,
   },
   filler: {
     flex: 1,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Currently on some mobile device there are content overlapping issues involving recommended library badge and secondary metadata bar. This PR fixes the problem aby altering a bit the styling of bottom part of libraries box when on mobile and changes the flex direction for the libraries box heading in a way which places the elements in rows (rather than columns). 

I have also added the missing key to the platform tags to fix the React warning appearing in the console.

> Some data are missing on my local app, but the problem and solution should still be visible.

### Before
![IMG-6802](https://user-images.githubusercontent.com/719641/96043056-aefdeb80-0e6e-11eb-81ce-92af01d5342e.PNG)

### After
![IMG-6801](https://user-images.githubusercontent.com/719641/96043061-b1604580-0e6e-11eb-9de6-77c31e17b4ed.PNG)

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
