### PR TITLE
merge package.json and GitHub topics, update and cleanup libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "data:update": "babel-node scripts/build-and-score-data.js --presets @babel/preset-env",
     "data:test": "babel-node scripts/validate-libraries.js --presets @babel/preset-env",
     "data:validate": "ajv validate -s react-native-libraries.schema.json -d react-native-libraries.json --verbose",
-    "libraries:cleanup": "babel-node scripts/cleanup-libraries-json.js --presets @babel/preset-env"
+    "libraries:cleanup": "babel-node scripts/cleanup-libraries-json.js --presets @babel/preset-env && yarn libraries:format",
+    "libraries:format": "prettier --write react-native-libraries.json"
   },
   "dependencies": {
     "@expo/html-elements": "^0.0.0",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1881,12 +1881,6 @@
     "unmaintained": true
   },
   {
-    "githubUrl": "https://github.com/joao-alberto/react-native-tilt",
-    "ios": true,
-    "android": true,
-    "expo": true
-  },
-  {
     "githubUrl": "https://github.com/Polidea/react-native-ble-plx",
     "ios": true,
     "android": true
@@ -3121,9 +3115,19 @@
     "windows": true
   },
   {
-    "githubUrl": "https://github.com/microsoft/react-native-dualscreen",
+    "githubUrl": "https://github.com/microsoft/react-native-dualscreen/tree/master/dualscreeninfo",
     "android": true,
     "npmPkg": "react-native-dualscreeninfo"
+  },
+  {
+    "githubUrl": "https://github.com/microsoft/react-native-dualscreen/tree/master/twopane-navigation",
+    "android": true,
+    "npmPkg": "react-native-twopane-navigation"
+  },
+  {
+    "githubUrl": "https://github.com/microsoft/react-native-dualscreen/tree/master/twopaneview",
+    "android": true,
+    "npmPkg": "react-native-twopaneview"
   },
   {
     "githubUrl": "https://github.com/expo/expo/tree/master/packages/expo-splash-screen",
@@ -3743,7 +3747,8 @@
   {
     "githubUrl": "https://github.com/luggit/react-native-config",
     "ios": true,
-    "android": true
+    "android": true,
+    "windows": true
   },
   {
     "githubUrl": "https://github.com/luisfcofv/react-native-deep-linking",
@@ -4222,7 +4227,8 @@
     "unmaintained": true
   },
   {
-    "githubUrl": "https://github.com/uxcam/react-native-ux-cam",
+    "githubUrl": "https://github.com/uxcam/react-native-ux-cam/tree/master/uxcam-react-wrapper",
+    "npmPkg": "react-native-ux-cam",
     "ios": true,
     "android": true
   },
@@ -5347,7 +5353,9 @@
   },
   {
     "githubUrl": "https://github.com/WrathChaos/react-native-bouncy-checkbox",
-    "images": ["https://github.com/WrathChaos/react-native-bouncy-checkbox/raw/master/assets/Screenshots/example.gif"],
+    "images": [
+      "https://github.com/WrathChaos/react-native-bouncy-checkbox/raw/master/assets/Screenshots/example.gif"
+    ],
     "ios": true,
     "android": true
   },
@@ -5368,8 +5376,9 @@
   },
   {
     "githubUrl": "https://github.com/facebook/flipper/tree/master/react-native/react-native-flipper",
-    "npmPkg": "react-native-flipper",
-    "examples": ["https://github.com/facebook/flipper/tree/master/react-native/ReactNativeFlipperExample"],
+    "examples": [
+      "https://github.com/facebook/flipper/tree/master/react-native/ReactNativeFlipperExample"
+    ],
     "ios": true,
     "android": true,
     "dev": true
@@ -5390,7 +5399,9 @@
   },
   {
     "githubUrl": "https://github.com/terrysahaidak/react-native-gallery-toolkit",
-    "examples": ["https://github.com/terrysahaidak/react-native-gallery-toolkit/tree/master/Example"],
+    "examples": [
+      "https://github.com/terrysahaidak/react-native-gallery-toolkit/tree/master/Example"
+    ],
     "images": [
       "https://github.com/terrysahaidak/react-native-gallery-toolkit/raw/master/gifs/promo.gif",
       "https://github.com/terrysahaidak/react-native-gallery-toolkit/raw/master/gifs/promo_2.gif"
@@ -5400,7 +5411,9 @@
   },
   {
     "githubUrl": "https://github.com/junedomingo/react-native-rename",
-    "images": ["https://cloud.githubusercontent.com/assets/5106887/24444940/cbcb0a58-149a-11e7-9714-2c7bf5254b0d.gif"],
+    "images": [
+      "https://cloud.githubusercontent.com/assets/5106887/24444940/cbcb0a58-149a-11e7-9714-2c7bf5254b0d.gif"
+    ],
     "ios": true,
     "android": true,
     "dev": true
@@ -5423,7 +5436,9 @@
   },
   {
     "githubUrl": "https://github.com/Naturalclar/react-native-color-picker-ios",
-    "examples": ["https://github.com/Naturalclar/react-native-color-picker-ios/tree/master/example"],
+    "examples": [
+      "https://github.com/Naturalclar/react-native-color-picker-ios/tree/master/example"
+    ],
     "images": [
       "https://user-images.githubusercontent.com/6936373/95818710-758a8a80-0d5f-11eb-8e45-fb0573049c34.jpeg",
       "https://user-images.githubusercontent.com/6936373/95818705-73283080-0d5f-11eb-8a10-c0f166ed13a9.jpeg",
@@ -5501,7 +5516,7 @@
   {
     "githubUrl": "https://github.com/nandorojo/dripsy",
     "examples": [
-      "https://github.com/nandorojo/dripsy/tree/master/next-example", 
+      "https://github.com/nandorojo/dripsy/tree/master/next-example",
       "https://github.com/nandorojo/dripsy/tree/master/example"
     ],
     "ios": true,
@@ -5527,7 +5542,9 @@
   },
   {
     "githubUrl": "https://github.com/dooboolab/react-native-audio-recorder-player",
-    "examples": ["https://github.com/dooboolab/react-native-audio-recorder-player/tree/master/Example"],
+    "examples": [
+      "https://github.com/dooboolab/react-native-audio-recorder-player/tree/master/Example"
+    ],
     "ios": true,
     "android": true
   },


### PR DESCRIPTION
# Why

Refs #484

This PR improves the topics gathered for library and search string generation. The current flow has been simplified and `package.json` keywords will be always extracted. For non-monorepo packages also the GitHub topic will be added (and the merge list will be deduplicated). 

This is not the full fix for the reference issues, but it should improve the search UX a bit.

#### Example of updated tags for `audio-toolkit`
![image](https://user-images.githubusercontent.com/719641/97438434-17e06b80-1925-11eb-9eb4-42c48e9cb230.png)

In addition the topics are being processed to address the whitespace character allowed in `package.json` keywords.

During work on the changes I have noticed one deleted library and few small warnings about moved packages - those problems have been also addressed. 

The last thing included in this PR is updated `libraries:cleanup` script which includes now `prettier` step like the `pre-commit` hook, so the cleanup results are consistent with final reformat.

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
