### PR TITLE
add react-native-paper-dates in json file

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5638,5 +5638,12 @@
     "githubUrl": "https://github.com/fasky-software/react-native-widgetkit",
     "examples": ["https://github.com/fasky-software/react-native-widgetkit/tree/main/example"],
     "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/web-ridge/react-native-paper-dates",
+    "examples": ["https://github.com/web-ridge/react-native-paper-dates/tree/master/example"],
+    "ios": true,
+    "android": true,
+    "web": true
   }
 ]


### PR DESCRIPTION
# Why
 This PR add [`react-native-paper-dates`](https://github.com/web-ridge/react-native-paper-dates) in json file.

 # Checklist
 * [x]  Added it to **react-native-libraries.json**
