### PR TITLE
Add the Formorama library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5638,5 +5638,15 @@
     "githubUrl": "https://github.com/fasky-software/react-native-widgetkit",
     "examples": ["https://github.com/fasky-software/react-native-widgetkit/tree/main/example"],
     "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/dezemand/formorama",
+    "nameOverride": "Formorama",
+    "examples": ["https://formorama.org/docs/example-reactnative"],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "windows": true,
+    "macos": true
   }
 ]


### PR DESCRIPTION
# Why
This library can be used in React Native to manage your forms. 

# Checklist
If you added a new library:

- [x] Added it to **react-native-libraries.json**