### PR TITLE
add react-native-navigation-bar-color to directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5668,5 +5668,14 @@
     "android": true,
     "web": true,
     "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/thebylito/react-native-navigation-bar-color",
+    "images": [
+      "https://raw.githubusercontent.com/thebylito/react-native-navigation-bar-color/master/screenshots/screenShot1.jpg",
+      "https://raw.githubusercontent.com/thebylito/react-native-navigation-bar-color/master/screenshots/screenShot2.jpg",
+      "https://raw.githubusercontent.com/thebylito/react-native-navigation-bar-color/master/screenshots/screenShot3.jpg"
+    ],
+    "android": true
   }
 ]


### PR DESCRIPTION
# Why

This PR adds [`react-native-navigation-bar-color`](https://github.com/thebylito/react-native-navigation-bar-color) library to the React Native Directory.

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**