### PR TITLE
add react-native-v8 library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5669,5 +5669,11 @@
     "githubUrl": "https://github.com/Kamalnrf/react-native-google-play-install-referrer",
     "examples": ["https://github.com/Kamalnrf/react-native-google-play-install-referrer/tree/main/example"],
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/Kudo/react-native-v8",
+    "ios": true,
+    "android": true,
+    "dev": true
   }
 ]


### PR DESCRIPTION
# Why

This PR adds [`react-native-v8`](https://github.com/Kudo/react-native-v8) library to the directory.

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**
