### PR TITLE
correct npmPkg name for flat-list-mvcp

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5739,6 +5739,7 @@
   },
   {
     "githubUrl": "https://github.com/GetStream/flat-list-mvcp",
+    "npmPkg": "@stream-io/flat-list-mvcp",
     "ios": true,
     "android": true
   },


### PR DESCRIPTION
This small PR adds the missing `npmPkg` name to the lately added `flat-list-mvcp` package.

https://www.npmjs.com/package/@stream-io/flat-list-mvcp