### PR TITLE
add react-native-default-preference to directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5840,5 +5840,10 @@
     "ios": true,
     "android": true,
     "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/kevinresol/react-native-default-preference",
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
# Why

This PR adds [`react-native-default-preference`](https://github.com/kevinresol/react-native-default-preference) to the directory.

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**
