### PR TITLE
attempt to speed up deploy but optimizing NPM retries

### DIFF
--- a/scripts/build-and-score-data.js
+++ b/scripts/build-and-score-data.js
@@ -24,8 +24,10 @@ const JSON_OPTIONS = {
   spaces: 2,
 };
 
-export const sleep = (ms = 0) => {
-  return new Promise(r => setTimeout(r, ms));
+export const sleep = (ms = 0, msMax = null) => {
+  return new Promise(r =>
+    setTimeout(r, msMax ? Math.floor(Math.random() * (msMax - ms)) + ms : ms)
+  );
 };
 
 let invalidRepos = [];

--- a/scripts/fetch-npm-data.js
+++ b/scripts/fetch-npm-data.js
@@ -6,7 +6,7 @@ const urlForPackage = npmPkg => {
   return `https://api.npmjs.org/downloads/point/last-month/${npmPkg}`;
 };
 
-const fetchNpmData = async (data, npmPkg, githubUrl) => {
+const fetchNpmData = async (data, npmPkg, githubUrl, attemptsCount = 0) => {
   if (!npmPkg) {
     let parts = githubUrl.split('/');
     npmPkg = parts[parts.length - 1].toLowerCase();
@@ -35,9 +35,9 @@ const fetchNpmData = async (data, npmPkg, githubUrl) => {
       },
     };
   } catch (e) {
-    console.log(`[NPM] Retrying fetch for ${githubUrl}`);
-    await sleep(2000);
-    return await fetchNpmData(data, npmPkg, githubUrl);
+    await sleep(1000 + 1000 * attemptsCount, 2000 + 1000 * attemptsCount);
+    console.log(`[NPM] Retrying fetch for ${npmPkg} (${attemptsCount + 1})`);
+    return await fetchNpmData(data, npmPkg, githubUrl, attemptsCount + 1);
   }
 };
 


### PR DESCRIPTION
# Why

This PR aims to speedup deployment process which is at this moment choked by the NPM retries. Currently all the NPM retry request were executed almost at the same time, which could irritate the NPM API. The idea behind the change is to assign the random timeout from given range and increase the `sleep` range with each try.

After the changes I was able to finish `yarn data:update` in several minutes, it time to try this on Vercel.

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
