### PR TITLE
@react-native-community/peek-and-pop doesn't exist in npm registry

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3547,11 +3547,6 @@
     "npmPkg": "@react-native-community/checkbox"
   },
   {
-    "githubUrl": "https://github.com/satya164/peek-and-pop",
-    "ios": true,
-    "npmPkg": "@react-native-community/peek-and-pop"
-  },
-  {
     "githubUrl": "https://github.com/react-native-google-signin/google-signin",
     "ios": true,
     "android": true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

During my local test on NPM API timeouts I have noticed the warning in the logs stating that `@react-native-community/peek-and-pop` doesn't exist in NPM registry. I have checked this manually and it looks like package is not available anymore (GH repo still exists, but under different owner), let's remove it for now.
