### PR TITLE
catch package.json parsing errors

### DIFF
--- a/scripts/fetch-github-data.js
+++ b/scripts/fetch-github-data.js
@@ -229,35 +229,40 @@ const processTopics = topics =>
 
 const createRepoDataWithResponse = (json, monorepo) => {
   if (json.packageJson) {
-    const packageJson = JSON.parse(json.packageJson.text);
+    try {
+      const packageJson = JSON.parse(json.packageJson.text);
 
-    if (monorepo) {
-      json.homepageUrl = packageJson.homepage;
-      json.name = packageJson.name;
-      json.topics = processTopics(packageJson.keywords);
-      json.description = packageJson.description;
-      json.licenseInfo = getLicenseFromPackageJson(packageJson);
-    }
-
-    if (!monorepo) {
-      json.topics = [
-        ...new Set([
-          ...processTopics(packageJson.keywords),
-          ...processTopics(json.repositoryTopics.nodes.map(({ topic }) => topic.name)),
-        ]),
-      ];
-
-      if (!json.description) {
+      if (monorepo) {
+        json.homepageUrl = packageJson.homepage;
+        json.name = packageJson.name;
+        json.topics = processTopics(packageJson.keywords);
         json.description = packageJson.description;
+        json.licenseInfo = getLicenseFromPackageJson(packageJson);
       }
 
-      if (!json.licenseInfo || (json.licenseInfo && json.licenseInfo.key === 'other')) {
-        json.licenseInfo = getLicenseFromPackageJson(packageJson) || json.licenseInfo;
-      }
-    }
+      if (!monorepo) {
+        json.topics = [
+          ...new Set([
+            ...processTopics(packageJson.keywords),
+            ...processTopics(json.repositoryTopics.nodes.map(({ topic }) => topic.name)),
+          ]),
+        ];
 
-    if (packageJson.types || packageJson.typings) {
-      json.types = true;
+        if (!json.description) {
+          json.description = packageJson.description;
+        }
+
+        if (!json.licenseInfo || (json.licenseInfo && json.licenseInfo.key === 'other')) {
+          json.licenseInfo = getLicenseFromPackageJson(packageJson) || json.licenseInfo;
+        }
+      }
+
+      if (packageJson.types || packageJson.typings) {
+        json.types = true;
+      }
+    } catch (e) {
+      console.warn(`Unable to parse ${json.name} package.json file!`);
+      console.error(e);
     }
   }
 


### PR DESCRIPTION
# Why

Rarely `package.json` fetched from GitHub might contain syntax errors. This lately has happened to the one of the libraries in the Directory. Let's add an additional try to catch `package.json` parsing errors to prevent spam in logs and make the debugging easier.

# Checklist

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
