### PR TITLE
use correct font settings for sort select

### DIFF
--- a/components/Sort.tsx
+++ b/components/Sort.tsx
@@ -120,5 +120,7 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     position: 'relative',
     top: -1,
+    fontSize: 14,
+    fontFamily: 'System',
   },
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Currently `<select>` tag used in sort selector do not use the correct font settings (typeface used there was different than everywhere on the page), due to the CSS styles reset which is applied globally, and `<select>` do not have a proper reapply within `html-elements`. The issue was mostly noticeable on Windows. 

This small PR fixes the font issue simply by setting font size to desired one, and font family to best, safe value, which is "System".

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how to use the feature or replicate the bug.

### Preview
![sel](https://user-images.githubusercontent.com/719641/109397280-45224200-7936-11eb-9365-e9653c4e3666.gif)

