### PR TITLE
add react-native-hold-menu to the Directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6062,5 +6062,16 @@
      ],
      "ios": true,
      "android": true
+  },
+  {
+     "githubUrl": "https://github.com/enesozturk/react-native-hold-menu",
+     "examples": [
+       "https://github.com/enesozturk/react-native-hold-menu/tree/main/example"
+     ],
+     "images": [
+       "https://i.imgur.com/VzjQ4n8.gif"
+     ],
+     "ios": true,
+     "android": true
   }
 ]


### PR DESCRIPTION
# Why

This PR adds [`react-native-hold-menu`](https://github.com/enesozturk/react-native-hold-menu) library to the Directory.

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**