### PR TITLE
fix NPM downloads fetch issue with bulk queries

### DIFF
--- a/debug-github-repos.json
+++ b/debug-github-repos.json
@@ -14,5 +14,10 @@
   { "githubUrl": "https://github.com/BugiDev/react-native-calendar-strip", "expo": true },
   { "githubUrl": "https://github.com/archriss/react-native-render-html", "expo": true },
   { "githubUrl": "https://github.com/react-native-community/react-native-picker", "expo": true },
-  { "githubUrl": "https://github.com/th3rdwave/react-native-safe-area-context", "expo": true }
+  { "githubUrl": "https://github.com/th3rdwave/react-native-safe-area-context", "expo": true },
+  {
+    "githubUrl": "https://github.com/react-native-datetimepicker/datetimepicker",
+    "npmPkg": "@react-native-community/datetimepicker",
+    "expo": true
+  }
 ]

--- a/scripts/fetch-npm-data.js
+++ b/scripts/fetch-npm-data.js
@@ -6,13 +6,38 @@ const urlForPackage = (npmPkg, period = 'month') => {
   return `https://api.npmjs.org/downloads/point/last-${period}/${npmPkg}`;
 };
 
-const fetchNpmData = async (data, npmPkg, githubUrl, attemptsCount = 0) => {
-  if (!npmPkg) {
-    let parts = githubUrl.split('/');
-    npmPkg = parts[parts.length - 1].toLowerCase();
-    data.npmPkg = npmPkg;
-  }
+export const fetchNpmDataBulk = async (data, npmPkgs, attemptsCount = 0) => {
+  try {
+    const url = urlForPackage(npmPkgs.join(','));
+    let response = await fetch(url);
+    let downloadData = await response.json();
 
+    return npmPkgs.map(pkg => {
+      if (!downloadData[pkg].downloads) {
+        console.warn(
+          `[NPM] ${pkg} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
+        );
+        return { npm: null };
+      }
+
+      return {
+        pkgName: pkg,
+        npm: {
+          downloads: downloadData[pkg].downloads,
+          start: downloadData[pkg].start,
+          end: downloadData[pkg].end,
+          period: 'month',
+        },
+      };
+    });
+  } catch (e) {
+    await sleep(1000 + 250 * attemptsCount, 2000 + 500 * attemptsCount);
+    console.log(`[NPM] Retrying fetch for ${npmPkgs} (${attemptsCount + 1})`);
+    return await fetchNpmDataBulk(data, npmPkgs, attemptsCount + 1);
+  }
+};
+
+export const fetchNpmData = async (data, npmPkg, attemptsCount = 0) => {
   try {
     const url = urlForPackage(npmPkg);
     let response = await fetch(url);
@@ -22,7 +47,7 @@ const fetchNpmData = async (data, npmPkg, githubUrl, attemptsCount = 0) => {
       console.warn(
         `[NPM] ${npmPkg} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
       );
-      return { ...data, npm: {} };
+      return { ...data, npm: null };
     }
 
     return {
@@ -37,8 +62,6 @@ const fetchNpmData = async (data, npmPkg, githubUrl, attemptsCount = 0) => {
   } catch (e) {
     await sleep(1000 + 250 * attemptsCount, 2000 + 500 * attemptsCount);
     console.log(`[NPM] Retrying fetch for ${npmPkg} (${attemptsCount + 1})`);
-    return await fetchNpmData(data, npmPkg, githubUrl, attemptsCount + 1);
+    return await fetchNpmData(data, npmPkg, attemptsCount + 1);
   }
 };
-
-export default fetchNpmData;

--- a/scripts/fetch-readme-images.js
+++ b/scripts/fetch-readme-images.js
@@ -41,12 +41,12 @@ const scrapeImagesAsync = async githubUrl => {
   }
 };
 
-const fetchReadmeImages = async (data, githubUrl) => {
+const fetchReadmeImages = async (data, githubUrl, attemptsCount = 0) => {
   /**
    * @DEV
-   * if images been set, we skip scraping images
+   * if images been set, or max attempt count has been reached, we skip scraping images
    */
-  if (data.images) {
+  if (data.images || attemptsCount > 5) {
     return data;
   }
 
@@ -58,9 +58,9 @@ const fetchReadmeImages = async (data, githubUrl) => {
       images,
     };
   } catch (e) {
-    console.log(`[GH] Retrying image scrape for ${githubUrl}`);
+    console.log(`[GH] Retrying image scrape for ${githubUrl} (${attemptsCount + 1})`);
     await sleep(2000);
-    return await fetchReadmeImages(data, githubUrl);
+    return await fetchReadmeImages(data, githubUrl, attemptsCount + 1);
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

ATM deploy of Directory takes about 35min, which most of time is due to NPM timeout while fetching download data.

This PR introduce the npm fetch rewrite and utilizes bulk queries (described here: https://github.com/npm/registry/blob/master/docs/download-counts.md#bulk-queries)

Unfortunately scoped packages in bulk queries are still not supported, so for scoped packages we use the old logic. 

Also the code might be cleaner if we will use `reduce` to partition the libraries list, but this will break the `data` original order, which we are using for `Recently added` sort option. 

I will try to refactor and cleanup a bit more in the future, if this solution will be feasible.

I have fetch the all data locally and validated with the actual deployment of Directory and I was not able to spot a difference.

Within this PR I have also added the max attempt count for GH images fetch, because on `localhost` script have an issues fetching `react-native-svg` images and was running in a loop (probably because of size of Readme file in this project).

CC: @brentvatne 

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
