### PR TITLE
add images and update libraries data

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -77,6 +77,7 @@
   {
     "githubUrl": "https://github.com/GetStream/stream-chat-react-native",
     "images": [
+      "https://raw.githubusercontent.com/GetStream/stream-chat-react-native/master/screenshots/readme/cover.png",
       "https://raw.githubusercontent.com/GetStream/stream-chat-react-native/master/screenshots/1.png",
       "https://raw.githubusercontent.com/GetStream/stream-chat-react-native/master/screenshots/2.png",
       "https://raw.githubusercontent.com/GetStream/stream-chat-react-native/master/screenshots/3.png"
@@ -436,11 +437,17 @@
   },
   {
     "githubUrl": "https://github.com/react-native-image-picker/react-native-image-picker",
+    "examples": [
+      "https://github.com/react-native-image-picker/react-native-image-picker/tree/main/example"
+    ],
     "ios": true,
     "android": true
   },
   {
     "githubUrl": "https://github.com/Andr3wHur5t/react-native-keyboard-spacer",
+    "images": [
+      "https://media.giphy.com/media/3oEjHJwLyYg7upTyYo/giphy.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -538,6 +545,12 @@
   },
   {
     "githubUrl": "https://github.com/wix/react-native-calendars",
+    "images": [
+      "https://raw.githubusercontent.com/wix/react-native-calendars/master/demo/calendar.gif",
+      "https://raw.githubusercontent.com/wix/react-native-calendars/master/demo/agenda.gif",
+      "https://raw.githubusercontent.com/wix/react-native-calendars/master/demo/multi-marking.png",
+      "https://raw.githubusercontent.com/wix/react-native-calendars/master/demo/calendar-list.gif"
+    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -600,6 +613,10 @@
   },
   {
     "githubUrl": "https://github.com/maxs15/react-native-modalbox",
+    "images": [
+      "https://i.imgur.com/QTAYh81.gif",
+      "https://i.imgur.com/3XULLt8.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -626,7 +643,11 @@
     "goldstar": true,
     "examples": [
       "https://snack.expo.io/HJjbO4nSW",
-      "https://expo.io/@satya164/react-native-tab-view-demos"
+      "https://expo.io/@satya164/react-native-tab-view-demos",
+      "https://github.com/satya164/react-native-tab-view/tree/main/example"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/satya164/react-native-tab-view/main/demo/demo.gif"
     ]
   },
   {
@@ -858,6 +879,9 @@
   },
   {
     "githubUrl": "https://github.com/obipawan/react-native-hyperlink",
+    "images": [
+      "https://cdn.rawgit.com/obipawan/hyperlink/master/asset/screen.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true,
@@ -945,6 +969,7 @@
     "ios": true,
     "android": true,
     "expo": true,
+    "unmaintained": true,
     "examples": ["https://snack.expo.io/HyQ25dU8Z"]
   },
   {
@@ -1215,6 +1240,9 @@
   },
   {
     "githubUrl": "https://github.com/joinspontaneous/react-native-loading-spinner-overlay",
+    "images": [
+      "https://raw.githubusercontent.com/joinspontaneous/react-native-loading-spinner-overlay/master/media/demo.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -1513,6 +1541,9 @@
   },
   {
     "githubUrl": "https://github.com/rt2zz/react-native-contacts",
+    "images": [
+      "https://raw.githubusercontent.com/morenoh149/react-native-contacts/raw/master/example/react-native-contacts.gif"
+    ],
     "ios": true,
     "android": true
   },
@@ -2946,12 +2977,18 @@
   },
   {
     "githubUrl": "https://github.com/n4kz/react-native-indicators",
+    "images": [
+      "https://user-images.githubusercontent.com/2055622/28246049-e82c70e8-6a1b-11e7-93cc-8aa6d0d19867.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true
   },
   {
-    "githubUrl": "https://github.com/Elyx0/react-native-document-picker",
+    "githubUrl": "https://github.com/rnmods/react-native-document-picker",
+    "images": [
+      "http://i.stack.imgur.com/dv0iQ.png"
+    ],
     "ios": true,
     "android": true
   },
@@ -2969,6 +3006,9 @@
   {
     "githubUrl": "https://github.com/ptomasroos/react-native-multi-slider",
     "npmPkg": "@ptomasroos/react-native-multi-slider",
+    "images": [
+      "https://raw.githubusercontent.com/ptomasroos/react-native-multi-slider/master/docs/demo.gif"
+    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -3003,6 +3043,12 @@
   },
   {
     "githubUrl": "https://github.com/osdnk/react-native-reanimated-bottom-sheet",
+    "images": [
+      "https://raw.githubusercontent.com/osdnk/react-native-reanimated-bottom-sheet/master/gifs/1.gif",
+      "https://raw.githubusercontent.com/osdnk/react-native-reanimated-bottom-sheet/master/gifs/2.gif",
+      "https://raw.githubusercontent.com/osdnk/react-native-reanimated-bottom-sheet/master/gifs/3.gif",
+      "https://raw.githubusercontent.com/osdnk/react-native-reanimated-bottom-sheet/master/gifs/4.gif"
+    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -3063,7 +3109,8 @@
     "githubUrl": "https://github.com/FormidableLabs/eslint-plugin-react-native-a11y",
     "ios": true,
     "android": true,
-    "expo": true
+    "expo": true,
+    "dev": true
   },
   {
     "githubUrl": "https://github.com/RosterBuster/rn-zendesk",
@@ -3072,6 +3119,9 @@
   },
   {
     "githubUrl": "https://github.com/react-native-progress-view/progress-bar-android",
+    "images": [
+      "https://user-images.githubusercontent.com/25158423/57262658-0d4c5b00-703b-11e9-9e0d-bdf7cb8f942a.gif"
+    ],
     "android": true,
     "npmPkg": "@react-native-community/progress-bar-android"
   },
@@ -3207,6 +3257,13 @@
   },
   {
     "githubUrl": "https://github.com/expo/expo/tree/master/packages/expo-splash-screen",
+    "images": [
+      "https://raw.githubusercontent.com/expo/expo/master/packages/expo-splash-screen/assets/demo-android-contain.gif",
+      "https://raw.githubusercontent.com/expo/expo/master/packages/expo-splash-screen/assets/demo-ios-contain.gif",
+      "https://raw.githubusercontent.com/expo/expo/master/packages/expo-splash-screen/assets/demo-android-cover.gif",
+      "https://raw.githubusercontent.com/expo/expo/master/packages/expo-splash-screen/assets/demo-ios-cover.gif",
+      "https://raw.githubusercontent.com/expo/expo/master/packages/expo-splash-screen/assets/demo-android-native.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -3222,7 +3279,8 @@
     "ios": true,
     "android": true,
     "web": true,
-    "expo": true
+    "expo": true,
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/expo/expo/tree/master/packages/expo-auth-session",
@@ -3276,6 +3334,9 @@
   {
     "githubUrl": "https://github.com/callstack/react-native-viewpager",
     "npmPkg": "@react-native-community/viewpager",
+    "images": [
+      "https://raw.githubusercontent.com/callstack/react-native-viewpager/master/docs/vp-carousel.gif"
+    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -3293,11 +3354,18 @@
   },
   {
     "githubUrl": "https://github.com/react-native-text-input-mask/react-native-text-input-mask",
+    "images": [
+      "https://s3.amazonaws.com/react-native-text-input-mask/react-native-text-input-mask-ios.gif",
+      "https://s3.amazonaws.com/react-native-text-input-mask/react-native-text-input-mask-android-updated.gif"
+    ],
     "ios": true,
     "android": true
   },
   {
     "githubUrl": "https://github.com/react-native-toolbar-android/toolbar-android",
+    "images": [
+      "https://raw.githubusercontent.com/react-native-toolbar-android/toolbar-android/master/screenShots/ToolbarAndroidExample.png"
+    ],
     "android": true,
     "npmPkg": "@react-native-community/toolbar-android"
   },
@@ -3323,6 +3391,9 @@
   },
   {
     "githubUrl": "https://github.com/Kureev/react-native-blur",
+    "images": [
+      "https://cloud.githubusercontent.com/assets/139536/25066337/3c9d44c0-224d-11e7-8ca6-028478bf4a7d.gif"
+    ],
     "ios": true,
     "android": true,
     "npmPkg": "@react-native-community/blur"
@@ -3339,11 +3410,19 @@
   },
   {
     "githubUrl": "https://github.com/react-native-picker/picker",
+    "images": [
+      "https://raw.githubusercontent.com/react-native-picker/picker/master/screenshots/picker-android.png",
+      "https://raw.githubusercontent.com/react-native-picker/picker/master/screenshots/picker-ios.png",
+      "https://raw.githubusercontent.com/react-native-picker/picker/master/screenshots/pickerios-ios.png",
+      "https://raw.githubusercontent.com/react-native-picker/picker/master/screenshots/picker-windows.png",
+      "https://raw.githubusercontent.com/react-native-picker/picker/master/screenshots/picker-macos.png"
+    ],
     "ios": true,
     "android": true,
     "web": true,
     "expo": true,
     "windows": true,
+    "macos": true,
     "npmPkg": "@react-native-picker/picker"
   },
   {
@@ -3360,6 +3439,9 @@
   },
   {
     "githubUrl": "https://github.com/react-native-masked-view/react-native-masked-view",
+    "images": [
+      "https://raw.githubusercontent.com/react-native-masked-view/masked-view/master/img/example.png"
+    ],
     "ios": true,
     "android": true,
     "expo": true,
@@ -3367,6 +3449,10 @@
   },
   {
     "githubUrl": "https://github.com/react-native-linear-gradient/react-native-linear-gradient",
+    "images": [
+      "https://raw.githubusercontent.com/react-native-community/react-native-linear-gradient/master/images/example.png",
+      "https://raw.githubusercontent.com/react-native-community/react-native-linear-gradient/master/images/example-animated.gif"
+    ],
     "ios": true,
     "android": true,
     "windows": true
@@ -3510,12 +3596,20 @@
   },
   {
     "githubUrl": "https://github.com/nirsky/react-native-size-matters",
+    "images": [
+      "https://raw.githubusercontent.com/nirsky/react-native-size-matters/master/examples/ipad.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true
   },
   {
     "githubUrl": "https://github.com/expo/react-native-action-sheet",
+    "images": [
+      "https://raw.githubusercontent.com/expo/react-native-action-sheet/master/gif/ios.gif",
+      "https://raw.githubusercontent.com/expo/react-native-action-sheet/master/gif/android.gif",
+      "https://raw.githubusercontent.com/expo/react-native-action-sheet/master/gif/web.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true,
@@ -3524,17 +3618,37 @@
   },
   {
     "githubUrl": "https://github.com/peacechen/react-native-modal-selector",
+    "images": [
+      "https://raw.githubusercontent.com/peacechen/react-native-modal-selector/master/docs/demo.gif"
+    ],
     "ios": true,
     "android": true
   },
   {
     "githubUrl": "https://github.com/JesperLekland/react-native-svg-charts",
+    "images": [
+      "https://raw.githubusercontent.com/jesperlekland/react-native-svg-charts/master/screenshots/area-chart.png",
+      "https://raw.githubusercontent.com/jesperlekland/react-native-svg-charts/master/screenshots/area-stack.png",
+      "https://raw.githubusercontent.com/jesperlekland/react-native-svg-charts/master/screenshots/bar-chart.png",
+      "https://raw.githubusercontent.com/jesperlekland/react-native-svg-charts/master/screenshots/bar-stack-horizontal.png",
+      "https://raw.githubusercontent.com/jesperlekland/react-native-svg-charts/master/screenshots/pie-chart.png",
+      "https://raw.githubusercontent.com/jesperlekland/react-native-svg-charts/master/screenshots/progress-circle.png",
+      "https://raw.githubusercontent.com/jesperlekland/react-native-svg-charts/master/screenshots/y-axis.png"
+    ],
     "ios": true,
     "android": true,
     "web": true
   },
   {
     "githubUrl": "https://github.com/react-native-svg/react-native-svg",
+    "images": [
+      "https://raw.githubusercontent.com/react-native-community/react-native-svg/master/screenshots/svg.png",
+      "https://raw.githubusercontent.com/react-native-community/react-native-svg/master/screenshots/pencil.png",
+      "https://raw.githubusercontent.com/react-native-community/react-native-svg/master/screenshots/tspan.png",
+      "https://raw.githubusercontent.com/react-native-community/react-native-svg/master/screenshots/text-path.png",
+      "https://raw.githubusercontent.com/react-native-community/react-native-svg/master/screenshots/text.png",
+      "https://raw.githubusercontent.com/react-native-community/react-native-svg/master/screenshots/path.png"
+    ],
     "ios": true,
     "android": true,
     "expo": true,
@@ -3587,11 +3701,20 @@
   },
   {
     "githubUrl": "https://github.com/DylanVann/react-native-fast-image",
+    "images": [
+      "https://raw.githubusercontent.com/DylanVann/react-native-fast-image/master/docs/assets/scroll.gif",
+      "https://raw.githubusercontent.com/DylanVann/react-native-fast-image/master/docs/assets/priority.gif"
+    ],
     "ios": true,
     "android": true
   },
   {
     "githubUrl": "https://github.com/ascoders/react-native-image-viewer",
+    "images": [
+      "https://cloud.githubusercontent.com/assets/7970947/21086300/388dedfc-c056-11e6-955e-0a2a0b541f7f.gif",
+      "https://cloud.githubusercontent.com/assets/7970947/21086323/7355face-c056-11e6-8d68-384000d41d47.gif",
+      "https://user-images.githubusercontent.com/7970947/37651584-8b642458-2c73-11e8-9ecc-ef7c72aca1be.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true,
@@ -3825,6 +3948,10 @@
   },
   {
     "githubUrl": "https://github.com/iou90/react-native-autoheight-webview",
+    "images": [
+      "https://media.giphy.com/media/tocJYDUGCgwac0kkyB/giphy.gif",
+      "https://media.giphy.com/media/9JyX1wZshYIxuPklHK/giphy.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -3937,6 +4064,9 @@
   },
   {
     "githubUrl": "https://github.com/jsdf/react-native-htmlview",
+    "images": [
+      "https://i.imgur.com/FYOgBYc.png"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -4050,6 +4180,9 @@
   },
   {
     "githubUrl": "https://github.com/tomzaku/react-native-shimmer-placeholder",
+    "images": [
+      "https://raw.githubusercontent.com/tomzaku/react-native-shimmer-placeholder/master/example.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -4150,6 +4283,10 @@
   },
   {
     "githubUrl": "https://github.com/Flipkart/recyclerlistview",
+    "images": [
+      "https://img.youtube.com/vi/Tnv4HMmPgMc/0.jpg",
+      "https://raw.githubusercontent.com/Flipkart/recyclerlistview/master/docs/images/getWindowCorrection_demo.gif"
+    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -4185,6 +4322,9 @@
   },
   {
     "githubUrl": "https://github.com/magicismight/react-native-root-toast",
+    "images": [
+      "https://raw.githubusercontent.com/magicismight/react-native-root-toast/master/Example/screen-shoots.gif"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -4261,8 +4401,7 @@
   {
     "githubUrl": "https://github.com/christopherdro/react-native-html-to-pdf",
     "ios": true,
-    "android": true,
-    "unmaintained": true
+    "android": true
   },
   {
     "githubUrl": "https://github.com/almost/react-native-html-webview",
@@ -4285,6 +4424,9 @@
   },
   {
     "githubUrl": "https://github.com/vinzscam/react-native-file-viewer",
+    "images": [
+      "https://raw.githubusercontent.com/vinzscam/react-native-file-viewer/master/docs/react-native-file-viewer-usage-example.gif"
+    ],
     "ios": true,
     "android": true,
     "windows": true
@@ -4449,6 +4591,9 @@
   },
   {
     "githubUrl": "https://github.com/davidohayon669/react-native-youtube",
+    "images": [
+      "https://raw.githubusercontent.com/davidohayon669/react-native-youtube/master/Screenshot.png"
+    ],
     "ios": true,
     "android": true
   },
@@ -4980,6 +5125,12 @@
       "https://snack.expo.io/Zil!jCFft",
       "https://github.com/retyui/react-native-confirmation-code-field/tree/master/examples/DemoCodeField"
     ],
+    "images": [
+      "https://media.giphy.com/media/huJrqF0YRrNJBTwUmz/giphy.gif",
+      "https://media.giphy.com/media/L4HHvT9Rwdlcdj59np/giphy.gif",
+      "https://media.giphy.com/media/jslJYqajRARsyANwdf/giphy.gif",
+      "https://media.giphy.com/media/XEazF64IwELNV8wZge/giphy.gif"
+    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -5017,6 +5168,11 @@
   {
     "githubUrl": "https://github.com/jacse/react-native-app-intro-slider",
     "examples": ["https://github.com/Jacse/react-native-app-intro-slider/tree/master/examples"],
+    "images": [
+      "https://raw.githubusercontent.com/Jacse/react-native-app-intro-slider/master/Images/basic-example.gif",
+      "https://raw.githubusercontent.com/Jacse/react-native-app-intro-slider/master/Images/skipbutton-example.jpg",
+      "https://raw.githubusercontent.com/Jacse/react-native-app-intro-slider/master/Images/bottomskipbutton-example.jpg"
+    ],
     "ios": true,
     "android": true
   },
@@ -5354,6 +5510,9 @@
     "npmPkg": "@invertase/react-native-apple-authentication",
     "examples": [
       "https://github.com/invertase/react-native-apple-authentication/tree/master/example"
+    ],
+    "images": [
+      "https://static.invertase.io/assets/apple-auth.png"
     ],
     "ios": true
   },
@@ -5738,6 +5897,9 @@
   {
     "githubUrl": "https://github.com/web-ridge/react-native-paper-dates",
     "examples": ["https://github.com/web-ridge/react-native-paper-dates/tree/master/example"],
+    "images": [
+      "https://user-images.githubusercontent.com/6492229/98866767-bd3f2780-246d-11eb-890e-3491b47c95c5.gif"
+    ],
     "ios": true,
     "android": true,
     "web": true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Recent changes to the way which GitHub serves the images make a lot difficult for our scrapper to extract the images from Readme files. I'm planning to look on this problem and how we can improve scrapping in the future, but for now I have manually  added bunch of images which were problematic to extract.

I have also update few libraries statuses, examples and flags.
