### PR TITLE
small tweaks for Explore page, iOS icon fix

### DIFF
--- a/components/Explore/ExploreSection.tsx
+++ b/components/Explore/ExploreSection.tsx
@@ -60,7 +60,7 @@ const ExploreSection = ({
     <>
       <H3 style={styles.subHeader} nativeID={hashLink}>
         <View style={styles.subHeaderIcon}>
-          {React.createElement(icon, { fill: color, width: 28, height: 30 })}
+          {React.createElement(icon, { fill: color, width: 30, height: 30 })}
         </View>
         <A
           href={`#${hashLink}`}
@@ -104,6 +104,7 @@ const styles = StyleSheet.create({
   },
   subHeaderTitle: {
     marginTop: 16,
+    fontSize: 26,
     fontWeight: '700',
     textDecorationLine: 'none',
     backgroundColor: 'transparent',

--- a/components/Icons/index.tsx
+++ b/components/Icons/index.tsx
@@ -315,11 +315,11 @@ export function PlatformMacOS(props: Props) {
 export function PlatformIOS(props: Props) {
   const { width = 18, height = 18, fill = colors.black } = props;
   return (
-    <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
-      <Path d="M7 5h10v14H7z" opacity=".3" fill={fill} />
+    <Svg width={width} height={height} viewBox="0 0 18 18" fill="none">
+      <Path d="M5 2.5h8v13H5v-13z" opacity=".3" fill={fill} />
       <Path
         fill={fill}
-        d="M17 1.01L7 1c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z"
+        d="M12.9 0H5.1c-1 0-1.6.7-1.6 1.6v14.8c0 .9.7 1.6 1.6 1.6H13c.8 0 1.6-.7 1.6-1.6V1.6C14.5.7 13.8 0 12.9 0zm.1 15.5H5v-13h8v13z"
       />
     </Svg>
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Currently few of icons used in the Explore page headers seems a bit misaligned with the header text.

This PR aims to fix this issue by applying two small style tweaks and improving the iOS SVG code.

# Preview

<img width="852" alt="Screenshot 2021-03-08 232544" src="https://user-images.githubusercontent.com/719641/110390073-b6b06d80-8065-11eb-981b-7be291e66743.png">

