### PR TITLE
add test deploy workflow, update setup-node

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ~12.16.3
-      uses: actions/setup-node@v1
+    - name: Use Node.js 14
+      uses: actions/setup-node@v2
       with:
-        node-version: '~12.16.3'
+        node-version: '14'
     - name: Deploy
       shell: bash
       run: npx vercel --force --token "$VERCEL_TOKEN" --prod

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,25 @@
+name: Test deploy
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  build:
+    if: ${{ github.event.label.name == 'deploy' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Deploy
+        shell: bash
+        run: npx vercel --force --token "$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          # https://spectrum.chat/zeit/now/solved-project-linking-and-ci-cd-pipelines~5e6eb62a-9d56-47ac-9e32-0d973a523787
+          VERCEL_ORG_ID: 'team_IsLEAhLb9cZj6y1Bud9XYmeK'
+          VERCEL_PROJECT_ID: 'QmecQ8hTu4DUHv6js5U8L9pJ9vp54mg1bmRLWaS5RZCyt4'


### PR DESCRIPTION
# Why

It would be nice to have an ability to deploy test version of selected PRs. 

This changeset adds that ability, and will activate on PRs with the `deploy` label.

The action code is based on production script, but skips the `--prod` which should be enough, according to Vercel docs:
* https://vercel.com/docs/platform/deployments#vercel-cli

# Checklist

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
