### PR TITLE
Add @klarna/platform-colors

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6311,5 +6311,12 @@
     ],
     "android": true,
     "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/klarna-incubator/platform-colors",
+    "android": true,
+    "ios": true,
+    "web": true,
+    "dev": true
   }
 ]


### PR DESCRIPTION
# Why

This PR adds [`@klarna/platform-colors`](https://github.com/klarna-incubator/platform-colors) CLI tool to the directory that is used to scaffold native color definitions for react-native et al. 

# Checklist

- [x] Added it to **react-native-libraries.json**

