### PR TITLE
add Expo support to react-native-view-shot

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1506,7 +1506,8 @@
   {
     "githubUrl": "https://github.com/gre/react-native-view-shot",
     "ios": true,
-    "android": true
+    "android": true,
+    "expo": true
   },
   {
     "githubUrl": "https://github.com/naoufal/react-native-safari-view",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

`react-native-view-shot` supports Expo and the information was currently missing:
* https://github.com/gre/react-native-view-shot#install
* https://docs.expo.io/versions/latest/sdk/captureRef/
