### PR TITLE
add react-native-popable back, add few other libraries

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6331,5 +6331,43 @@
     "ios": true,
     "web": true,
     "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/eveningkid/react-native-popable",
+    "examples": [
+      "https://github.com/eveningkid/react-native-popable/tree/main/example"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/eveningkid/react-native-popable/main/assets/popable.gif"
+    ],
+    "android": true,
+    "ios": true,
+    "web": true,
+    "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/swushi/react-native-input-outline",
+    "examples": [
+      "https://github.com/swushi/react-native-input-outline/tree/main/example"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/swushi/react-native-input-outline/main/mockup.png"
+    ],
+    "android": true,
+    "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/ihor/react-native-scalable-image",
+    "android": true,
+    "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/homeeondemand/react-native-mapbox-navigation",
+    "npmPkg": "@homee/react-native-mapbox-navigation",
+    "images": [
+      "https://raw.githubusercontent.com/homeeondemand/react-native-mapbox-navigation/master/img/ios-nav.png"
+    ],
+    "android": true,
+    "ios": true
   }
 ]


### PR DESCRIPTION
# Why

This PR adds `react-native-popable` back to the Directory as well as few other libraries:
* `react-native-input-outline`
* `react-native-scalable-image`
* `@homee/react-native-mapbox-navigation`

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**