### PR TITLE
introduce "template" tag, mark entries, small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Please follow this format, fields order and indentation:
   "windows": false,
   "macos": false,
   "unmaintained": false,
-  "dev": false
+  "dev": false,
+  "template": false
 }
 ```
 
@@ -81,6 +82,7 @@ Please skip the `false` values and do not fill optional fields, unless it's nece
 - `macos` - (_optional_ boolean) - can be used with [`react-native-macos`](https://github.com/microsoft/react-native-macos).
 - `unmaintained` - (_optional_ boolean) - signify that a library is not maintained.
 - `dev` - (_optional_ boolean) - signify that a library is a development tool.
+- `template` - (_optional_ boolean) - signify that a library is a project template.
 
 > _Note:_ If your package is within a monorepo on GitHub, eg: https://github.com/expo/expo/tree/master/packages/expo-web-browser, then the name, description, homepage, and topics (keywords) will be extracted from package.json for that subrepo. GitHub stats will be based on the monorepo, because there isn't really another option.
 

--- a/components/CompatibilityTags.tsx
+++ b/components/CompatibilityTags.tsx
@@ -11,26 +11,26 @@ type Props = {
 };
 
 type TagProps = {
-  platform: string;
+  label: string;
   tagStyle: ViewStyle;
   showCheck?: boolean;
 };
 
-const Tag = ({ platform, tagStyle, showCheck = true }: TagProps) => {
+const Tag = ({ label, tagStyle, showCheck = true }: TagProps) => {
   const { isDark } = useContext(CustomAppearanceContext);
   return (
-    <View key={platform} style={[styles.tag, tagStyle]}>
+    <View key={label} style={[styles.tag, tagStyle]}>
       {showCheck ? (
         <Check width={14} height={10} fill={isDark ? darkColors.secondary : undefined} />
       ) : null}
       <Label
         style={[
-          styles.text,
+          showCheck ? styles.textWithIcon : styles.text,
           {
             color: isDark ? darkColors.secondary : colors.black,
           },
         ]}>
-        {platform}
+        {label}
       </Label>
     </View>
   );
@@ -41,7 +41,7 @@ export function CompatibilityTags(props: Props) {
   const { library } = props;
   const platforms = [
     library.android ? 'Android' : null,
-    library.expo && typeof library.expo !== 'string' ? 'Expo Go' : null,
+    library.expo ? 'Expo Go' : null,
     library.ios ? 'iOS' : null,
     library.macos ? 'macOS' : null,
     library.tvos ? 'tvOS' : null,
@@ -55,7 +55,7 @@ export function CompatibilityTags(props: Props) {
     <View style={styles.container}>
       {library.dev ? (
         <Tag
-          platform="Development Tool"
+          label="Development Tool"
           tagStyle={{
             backgroundColor: isDark ? '#2b1c48' : '#e3d8f8',
             borderColor: isDark ? '#482f72' : '#d3c2f2',
@@ -63,9 +63,19 @@ export function CompatibilityTags(props: Props) {
           showCheck={false}
         />
       ) : null}
+      {library.template ? (
+        <Tag
+          label="Template"
+          tagStyle={{
+            backgroundColor: isDark ? '#173137' : '#d8f8f1',
+            borderColor: isDark ? '#28555a' : '#b2ddce',
+          }}
+          showCheck={false}
+        />
+      ) : null}
       {platforms.map(platform => (
         <Tag
-          platform={platform}
+          label={platform}
           key={`${platform}-platform`}
           tagStyle={{
             backgroundColor: isDark ? darkColors.dark : colors.gray1,
@@ -94,7 +104,10 @@ const styles = StyleSheet.create({
     paddingVertical: 4,
     marginBottom: 4,
   },
-  text: {
+  textWithIcon: {
     marginLeft: 4,
+  },
+  text: {
+    marginHorizontal: 4,
   },
 });

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,3 @@
-import { Header as HtmlHeader } from '@expo/html-elements/build/elements/Layout';
 import React, { FunctionComponent, SVGAttributes, useContext } from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
 

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3854,7 +3854,8 @@
   {
     "githubUrl": "https://github.com/react-native-community/react-native-template-typescript",
     "ios": true,
-    "android": true
+    "android": true,
+    "template": true
   },
   {
     "githubUrl": "https://github.com/react-native-audio-toolkit/react-native-audio-toolkit",
@@ -6184,7 +6185,8 @@
     "githubUrl": "https://github.com/gabrielmoncea/react-native-template",
     "npmPkg": "@gabrielmoncea/react-native-template",
     "ios": true,
-    "android": true
+    "android": true,
+    "template": true
   },
   {
     "githubUrl": "https://github.com/smallcasetech/react-native-simple-biometrics",

--- a/react-native-libraries.schema.json
+++ b/react-native-libraries.schema.json
@@ -13,7 +13,7 @@
       "githubUrl": {
         "$id": "#/items/properties/githubUrl",
         "type": "string",
-        "title": "The Githuburl Schema",
+        "title": "The GitHub URL Schema",
         "default": "",
         "examples": ["https://github.com/joshswan/react-native-autolink"],
         "pattern": "^(.*)$"
@@ -21,7 +21,7 @@
       "ios": {
         "$id": "#/items/properties/ios",
         "type": "boolean",
-        "title": "The Ios Schema",
+        "title": "The iOS Schema",
         "default": false,
         "examples": [true]
       },
@@ -49,7 +49,7 @@
       "expo": {
         "$id": "#/items/properties/expo",
         "type": "boolean",
-        "title": "The Expo Schema",
+        "title": "The Expo Go Schema",
         "default": false,
         "examples": [true]
       },
@@ -70,7 +70,7 @@
       "npmPkg": {
         "$id": "#/items/properties/npmPkg",
         "type": "string",
-        "title": "The Npmpkg Schema",
+        "title": "The NPM Package Schema",
         "default": "",
         "examples": ["@expo/ex-navigation"],
         "pattern": "^(.*)$"
@@ -108,6 +108,13 @@
         "$id": "#/items/properties/dev",
         "type": "boolean",
         "title": "The Development Tool Schema",
+        "default": false,
+        "examples": [true]
+      },
+      "template": {
+        "$id": "#/items/properties/template",
+        "type": "boolean",
+        "title": "The Template Schema",
         "default": false,
         "examples": [true]
       }

--- a/scripts/calculate-score.js
+++ b/scripts/calculate-score.js
@@ -61,7 +61,7 @@ const maxScore = modifiers.reduce((currentMax, modifier) => {
 }, 0);
 
 export const calculateScore = data => {
-  // Filter the modifiers to the ones which condictions pass with the data
+  // Filter the modifiers to the ones which conditions pass with the data
   const matchingModifiers = modifiers.filter(modifier => modifier.condition(data));
 
   // Reduce the matching modifiers to find the raw score for the data
@@ -123,7 +123,13 @@ export const calculatePopularity = data => {
   const freshPackagePenalty = DATE_NOW - new Date(createdAt) < WEEK_IN_MS ? 0.3 : 0;
 
   const popularity = parseFloat(
-    (popularityGain - downloadsPenalty - unmaintainedPenalty - starsPenalty - freshPackagePenalty).toFixed(3)
+    (
+      popularityGain -
+      downloadsPenalty -
+      unmaintainedPenalty -
+      starsPenalty -
+      freshPackagePenalty
+    ).toFixed(3)
   );
 
   return {

--- a/types/index.ts
+++ b/types/index.ts
@@ -42,6 +42,7 @@ export type Library = {
   tvos?: boolean;
   unmaintained?: boolean;
   dev?: boolean;
+  template?: boolean;
   github: {
     urls: {
       repo: string;


### PR DESCRIPTION
# Why

This PR adds the `template` boolean tag to the libraries schema, so the templates can be differentiated from the regular libraries (just like the "Developer Tools" with `dev` tag).

For now it is used only for small visual mark, no dedicated filter, just like Dev Tools tag. In the future we plan to utilize the new tag even more.

The changeset also includes small tweak to JSON Schema and fixes few Lint warnings.

### Preview
![temp](https://user-images.githubusercontent.com/719641/111967869-d7ae9f00-8af8-11eb-8304-2ce946c02e4b.gif)

# Checklist

- [X] Documented in this PR how you fixed or created the feature.
