### PR TITLE
speed up initial page render via dynamic imports

### DIFF
--- a/components/Libraries.tsx
+++ b/components/Libraries.tsx
@@ -1,13 +1,18 @@
+import dynamic from 'next/dynamic';
 import React from 'react';
 import { Image, StyleSheet, View } from 'react-native';
 
 import { H3, A, P } from '../common/styleguide';
 import { Library as LibraryType } from '../types';
-import Library from './Library';
+import LoadingContent from './Library/LoadingContent';
 
 type Props = {
   libraries: LibraryType[];
 };
+
+const LibraryWithLoading = dynamic(() => import('../components/Library'), {
+  loading: () => <LoadingContent />,
+});
 
 export default function Libraries(props: Props) {
   const { libraries } = props;
@@ -30,7 +35,7 @@ export default function Libraries(props: Props) {
   return (
     <View style={styles.librariesContainer}>
       {libraries.map((item: any, index: number) => (
-        <Library key={`list-item-${index}-${item.github.name}`} library={item} />
+        <LibraryWithLoading key={`list-item-${index}-${item.github.name}`} library={item} />
       ))}
     </View>
   );

--- a/components/Library/LoadingContent.tsx
+++ b/components/Library/LoadingContent.tsx
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import ContentLoader from 'react-content-loader';
+
+import { colors, darkColors } from '../../common/styleguide';
+import CustomAppearanceContext from '../../context/CustomAppearanceContext';
+
+const LoadingContent = () => {
+  const { isDark } = useContext(CustomAppearanceContext);
+  return (
+    <ContentLoader
+      speed={2}
+      width="100%"
+      height={206}
+      backgroundColor={isDark ? '#2a2e36' : '#f3f3f3'}
+      foregroundColor={isDark ? '#383c42' : '#ecebeb'}
+      style={{
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: isDark ? darkColors.border : colors.gray2,
+        borderRadius: 4,
+        marginBottom: 16,
+      }}>
+      <rect x="16" y="16" rx="3" ry="3" width="251" height="25" />
+      <rect x="16" y="56" rx="3" ry="3" width="62" height="16" />
+      <rect x="16" y="88" rx="3" ry="3" width="410" height="10" />
+      <rect x="16" y="106" rx="3" ry="3" width="380" height="10" />
+      <rect x="16" y="124" rx="3" ry="3" width="194" height="10" />
+      <rect x="90" y="56" rx="3" ry="3" width="62" height="16" />
+      <rect x="164" y="56" rx="3" ry="3" width="62" height="16" />
+      <rect x="16" y="180" rx="3" ry="3" width="306" height="14" />
+    </ContentLoader>
+  );
+};
+
+export default LoadingContent;

--- a/components/Library/LoadingContent.tsx
+++ b/components/Library/LoadingContent.tsx
@@ -20,14 +20,14 @@ const LoadingContent = () => {
         borderRadius: 4,
         marginBottom: 16,
       }}>
-      <rect x="16" y="16" rx="3" ry="3" width="251" height="25" />
-      <rect x="16" y="56" rx="3" ry="3" width="62" height="16" />
-      <rect x="16" y="88" rx="3" ry="3" width="410" height="10" />
-      <rect x="16" y="106" rx="3" ry="3" width="380" height="10" />
-      <rect x="16" y="124" rx="3" ry="3" width="194" height="10" />
-      <rect x="90" y="56" rx="3" ry="3" width="62" height="16" />
-      <rect x="164" y="56" rx="3" ry="3" width="62" height="16" />
-      <rect x="16" y="180" rx="3" ry="3" width="306" height="14" />
+      <rect x="20" y="16" rx="3" ry="3" width="251" height="25" />
+      <rect x="20" y="56" rx="3" ry="3" width="62" height="16" />
+      <rect x="20" y="88" rx="3" ry="3" width="410" height="10" />
+      <rect x="20" y="106" rx="3" ry="3" width="380" height="10" />
+      <rect x="20" y="124" rx="3" ry="3" width="194" height="10" />
+      <rect x="94" y="56" rx="3" ry="3" width="62" height="16" />
+      <rect x="168" y="56" rx="3" ry="3" width="62" height="16" />
+      <rect x="20" y="170" rx="3" ry="3" width="306" height="14" />
     </ContentLoader>
   );
 };

--- a/components/Library/Thumbnail.tsx
+++ b/components/Library/Thumbnail.tsx
@@ -34,7 +34,7 @@ const Thumbnail = ({ url }: Props) => {
 
   return (
     <>
-      <a
+      <div
         ref={iconRef}
         onMouseEnter={() => handleMouseEvent(true)}
         onMouseLeave={() => handleMouseEvent(false)}
@@ -54,7 +54,7 @@ const Thumbnail = ({ url }: Props) => {
           borderStyle: 'solid',
         }}>
         <ThumbnailIcon fill={iconFill} />
-      </a>
+      </div>
       {createPortal(
         <div ref={previewRef} style={styles.popper} {...attributes.popper}>
           {showPreview && (

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-native-web-hooks": "^3.0.1",
     "react-popper": "^2.2.5",
     "react-simple-linkify": "^1.0.3",
+    "react-content-loader": "^6.0.3",
     "use-debounce": "^5.2.1"
   },
   "devDependencies": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,16 +1,35 @@
 import fetch from 'isomorphic-fetch';
 import { NextPageContext } from 'next';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 
 import ContentContainer from '../components/ContentContainer';
-import Libraries from '../components/Libraries';
+import LoadingContent from '../components/Library/LoadingContent';
 import Navigation from '../components/Navigation';
 import Pagination from '../components/Pagination';
 import Search from '../components/Search';
 import getApiUrl from '../util/getApiUrl';
 import urlWithQuery from '../util/urlWithQuery';
+
+const LibrariesWithLoading = dynamic(() => import('../components/Libraries'), {
+  loading: () => (
+    <View
+      style={{
+        paddingTop: 8,
+      }}>
+      <LoadingContent />
+      <LoadingContent />
+      <LoadingContent />
+      <LoadingContent />
+      <LoadingContent />
+      <LoadingContent />
+      <LoadingContent />
+      <LoadingContent />
+    </View>
+  ),
+});
 
 const Index = ({ data, query }) => {
   const router = useRouter();
@@ -21,7 +40,7 @@ const Index = ({ data, query }) => {
       <Search query={router.query} total={total} />
       <ContentContainer style={styles.container}>
         <Pagination query={query} total={total} />
-        <Libraries libraries={data && data.libraries} />
+        <LibrariesWithLoading libraries={data && data.libraries} />
         <Pagination query={query} total={total} />
       </ContentContainer>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10060,6 +10060,11 @@ rc@^1.0.1, rc@^1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-content-loader@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-6.0.3.tgz#32e28ca7120e0a2552fc26655d0d4448cc1fc0c5"
+  integrity sha512-CIRgTHze+ls+jGDIfCitw27YkW2XcaMpsYORTUdBxsMFiKuUYMnlvY76dZE4Lsaa9vFXVw+41ieBEK7SJt0nug==
+
 react-dev-utils@~11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.1.tgz#30106c2055acfd6b047d2dc478a85c356e66fe45"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Currently the initial Directory page render could take a while, this is an attempt to speed it up using `next` [dynamic imports](https://nextjs.org/docs/advanced-features/dynamic-import) and `react-content-loader` SVG content skeletons.

# How

ATM the optimizations are applied only to the main page of Directory, the results are looking promising on the `localhost`, but the effect/benefit might differ in PROD (SSR) environment. Let's test it! 😄 

The solution also supports dark mode and should not degrade the functionality by any means.

# Preview

![ooo](https://user-images.githubusercontent.com/719641/114081370-c44b5400-98ac-11eb-99c7-e7c56b22b5eb.gif)
