### PR TITLE
reduce the number of DOM elements of Library component

### DIFF
--- a/components/Library/LoadingContent.tsx
+++ b/components/Library/LoadingContent.tsx
@@ -4,7 +4,7 @@ import ContentLoader from 'react-content-loader';
 import { colors, darkColors, useLayout } from '../../common/styleguide';
 import CustomAppearanceContext from '../../context/CustomAppearanceContext';
 
-const LoadingContent = ({ width = '100%', height = 206, wrapperStyle = {} }) => {
+const LoadingContent = ({ width = '100%', height = 204, wrapperStyle = {} }) => {
   const { isDark } = useContext(CustomAppearanceContext);
   const { isSmallScreen } = useLayout();
   return (

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -88,9 +88,9 @@ const generateData = (library, secondary, isDark) => {
         icon: <DirectoryScore score={library.score} />,
         content: (
           <A
-            target=""
+            target="_self"
             href="/directory-score"
-            style={styles.mutedLink}
+            style={[styles.link, styles.mutedLink]}
             hoverStyle={isDark ? { color: colors.primaryDark } : undefined}>
             Directory Score
           </A>
@@ -99,14 +99,14 @@ const generateData = (library, secondary, isDark) => {
       {
         id: 'calendar',
         icon: <Calendar fill={iconColor} />,
-        content: `Updated ${getTimeSinceToday(github.stats.pushedAt)}`,
+        content: <Caption>Updated {getTimeSinceToday(github.stats.pushedAt)}</Caption>,
       },
       library.npm.downloads
         ? {
             id: 'downloads',
-            icon: <Download fill={iconColor} />,
+            icon: <Download fill={iconColor} width={16} height={18} />,
             content: (
-              <A href={`https://www.npmjs.com/package/${library.npmPkg}`}>
+              <A href={`https://www.npmjs.com/package/${library.npmPkg}`} style={styles.link}>
                 {`${library.npm.downloads.toLocaleString()}`} {library.npm.period}ly downloads
               </A>
             ),
@@ -115,14 +115,14 @@ const generateData = (library, secondary, isDark) => {
       {
         id: 'star',
         icon: <Star fill={iconColor} />,
-        content: `${github.stats.stars.toLocaleString()} stars`,
+        content: <Caption>{github.stats.stars.toLocaleString()} stars</Caption>,
       },
       github.stats.forks
         ? {
             id: 'forks',
             icon: <Fork fill={iconColor} width={16} height={17} />,
             content: (
-              <A href={`${github.urls.repo}/network/members`}>
+              <A href={`${github.urls.repo}/network/members`} style={styles.link}>
                 {`${github.stats.forks.toLocaleString()}`} forks
               </A>
             ),
@@ -133,7 +133,7 @@ const generateData = (library, secondary, isDark) => {
             id: 'issues',
             icon: <Issue fill={iconColor} />,
             content: (
-              <A href={`${github.urls.repo}/issues`}>
+              <A href={`${github.urls.repo}/issues`} style={styles.link}>
                 {`${github.stats.issues.toLocaleString()}`} issues
               </A>
             ),
@@ -150,18 +150,18 @@ export function MetaData(props: Props) {
 
   return (
     <>
-      {data.filter(Boolean).map((datum, i) => (
+      {data.filter(Boolean).map(({ id, icon, content }, i) => (
         <View
-          key={datum.id}
+          key={id}
           style={[
             styles.displayHorizontal,
             i + 1 !== data.length ? styles.datumContainer : {},
             secondary ? styles.secondaryContainer : {},
           ]}>
           <View style={[styles.iconContainer, secondary ? styles.secondaryIconContainer : {}]}>
-            {datum.icon}
+            {icon}
           </View>
-          <Caption>{datum.content}</Caption>
+          {content}
         </View>
       ))}
     </>
@@ -171,6 +171,7 @@ export function MetaData(props: Props) {
 const styles = StyleSheet.create({
   datumContainer: {
     marginBottom: 8,
+    minHeight: 22,
   },
   displayHorizontal: {
     flexDirection: 'row',
@@ -180,6 +181,9 @@ const styles = StyleSheet.create({
     marginRight: 8,
     width: 20,
     alignItems: 'center',
+  },
+  link: {
+    fontSize: 15,
   },
   mutedLink: {
     backgroundColor: 'transparent',
@@ -197,5 +201,6 @@ const styles = StyleSheet.create({
   exampleLink: {
     marginLeft: 2,
     marginRight: 4,
+    fontSize: 13,
   },
 });


### PR DESCRIPTION
# Why

Currently `Library` component includes some wrappers in `MetaData` section which can be safely removed (with few tweaks) without effecting the overall layout and UI display. 

This is a performance improvement, DOM tree will be `~8-9%` smaller with full list of libraries loaded (20 entries).

# Tests

The changes have been tested by running the website on `localhost`. 

The Lighthouse results below were run on the same page, with the same search query and order, on current PROD and `localhost`.

### Before
<img width="533" alt="Screenshot 2021-04-19 160902" src="https://user-images.githubusercontent.com/719641/115251750-1e5cdc80-a12b-11eb-8ac7-c054ee575729.png">

### After
<img width="536" alt="Screenshot 2021-04-19 160846" src="https://user-images.githubusercontent.com/719641/115251732-18ff9200-a12b-11eb-85df-31b8caa52a2e.png">

CC: @brentvatne 
