### PR TITLE
temporary report 404 to Sentry for testing purpose

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -1,8 +1,12 @@
 import React from 'react';
+import * as Sentry from '@sentry/react';
+import { useRouter } from 'next/router';
 
 import ErrorState from '../components/ErrorState';
 
 export default function NotFound() {
-  // Opinionated: do not record an exception in Sentry for 404
+  const router = useRouter();
+  Sentry.captureException('CE404: ' + router.pathname);
+  Sentry.captureMessage('CM404: ' + router.pathname);
   return <ErrorState statusCode={404} />;
 }

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,6 +1,6 @@
-import React from 'react';
 import * as Sentry from '@sentry/react';
 import { useRouter } from 'next/router';
+import React from 'react';
 
 import ErrorState from '../components/ErrorState';
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/react';
-import { Integrations } from "@sentry/tracing";
+import { Integrations } from '@sentry/tracing';
 import Head from 'next/head';
 import React from 'react';
 import { AppearanceProvider } from 'react-native-appearance';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,7 +16,7 @@ import '../styles/styles.css';
 import PreviewStyles from '../styles/PreviewStyles';
 
 Sentry.init({
-  dsn: 'https://b084338633454a63a82c787541b96d8f@sentry.io/2503319',
+  dsn: 'https://d91de4406c74494dbfcadfd007774ba6@o574947.ingest.sentry.io/5727369',
   enabled: process.env.NODE_ENV === 'production',
   integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.5 : 1.0,


### PR DESCRIPTION
# Why

This PR switches to the new Sentry project and adds an ability to report 404 errors to test Sentry reporting setup in PROD using `captureException` and `captureMessage` methods.

The 404 error reporting should be reverted after the tests concludes.

CC: @brentvatne 