### PR TITLE
Adds react-native-blob-util library and mark rn-fetch-blob as unmaintained

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4898,7 +4898,8 @@
     "githubUrl": "https://github.com/joltup/rn-fetch-blob",
     "ios": true,
     "android": true,
-    "expo": true
+    "expo": true,
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/realtime-framework/RCTRealtimeMessagingIOS",
@@ -6526,5 +6527,15 @@
     "ios": true,
     "android": true,
     "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/RonRadtke/react-native-blob-util",
+    "examples": ["https://github.com/RonRadtke/react-native-blob-util/tree/master/examples"],
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": true,
+    "windows": true,
+    "macos": false
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6533,9 +6533,7 @@
     "examples": ["https://github.com/RonRadtke/react-native-blob-util/tree/master/examples"],
     "ios": true,
     "android": true,
-    "web": false,
     "expo": true,
-    "windows": true,
-    "macos": false
+    "windows": true
   }
 ]


### PR DESCRIPTION
…ained

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

<!--
Does this PR add a feature? Address a bug? Add a new library?

Document your changes here.
-->

# Adding lib react-native-blob-util
# marking rn-fetch-blobas unmaintianed (see https://github.com/joltup/rn-fetch-blob/issues/666). react-native-blob-util is an active fork of it adding new features, etc.

<!--
Check completed item, when applicable, via: [X]
-->

If you added a new library:

- [x ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
