### PR TITLE
add stripe-react-native in json file

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6569,5 +6569,11 @@
     "examples": ["https://github.com/firofame/react-native-compass-heading/tree/master/Example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/stripe/stripe-react-native",
+    "examples": ["https://github.com/stripe/stripe-react-native/tree/master/example"],
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
this PR add original stripe SDK for RN, @Simek  this library it's new,  i think for npm api probably has problems 

# Why
 This PR add [`stripe-react-native`](https://github.com/stripe/stripe-react-native) in json file.

 # Checklist
 * [x]  Added it to **react-native-libraries.json**