### PR TITLE
fix: CORS in libraries API

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,17 @@ module.exports = withExpo(
     withFonts({
       projectRoot: __dirname,
       productionBrowserSourceMaps: true,
+      async headers() {
+        return [
+          {
+            source: '/api/libraries',
+            headers: [
+              { key: 'Access-Control-Allow-Origin', value: '*' },
+              { key: 'Access-Control-Allow-Methods', value: 'GET,HEAD' },
+            ],
+          },
+        ];
+      },
     })
   )
 );

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "expo-font": "^9.1.0",
     "jsonfile": "^6.1.0",
     "lodash": "^4.17.21",
-    "micro-cors": "^0.1.1",
     "next": "^10.2.3",
     "node-emoji": "^1.10.0",
     "react": "16.13.1",
+    "react-content-loader": "^6.0.3",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-41.0.0.tar.gz",
     "react-native-appearance": "^0.3.4",
@@ -42,7 +42,6 @@
     "react-native-web-hooks": "^3.0.1",
     "react-popper": "^2.2.5",
     "react-simple-linkify": "^1.0.3",
-    "react-content-loader": "^6.0.3",
     "use-debounce": "^6.0.1"
   },
   "devDependencies": {
@@ -50,7 +49,6 @@
     "@babel/node": "^7.14.5",
     "@babel/preset-env": "^7.14.5",
     "@expo/next-adapter": "^2.1.78",
-    "@types/micro-cors": "^0.1.1",
     "@types/react": "^16.14.2",
     "@types/react-native": "0.63.40",
     "ajv-cli": "^4.2.0",

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -1,6 +1,5 @@
 import drop from 'lodash/drop';
 import take from 'lodash/take';
-import Cors from 'micro-cors';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 import { libraries } from '../../../assets/data.json';
@@ -34,7 +33,7 @@ const getAllowedOrderString = (req: NextApiRequest) => {
   return sortBy;
 };
 
-function handler(req: NextApiRequest, res: NextApiResponse) {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
   res.statusCode = 200;
   res.setHeader('Content-Type', 'application/json');
 
@@ -79,9 +78,3 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
     })
   );
 }
-
-const cors = Cors({
-  allowMethods: ['GET', 'HEAD'],
-});
-
-export default cors(handler);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,20 +2289,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/micro-cors@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@types/micro-cors/-/micro-cors-0.1.1.tgz#5a4d224e8c5640d6f7c531eb162f3c2657546ab9"
-  integrity sha512-0WciDHoP791RrwpuLyAELf0/k2owacf1FGwMOPZLlfnxFi5i2VapPnoe58ebDeY7ue7gZh5El4PJkE6rM8IVwA==
-  dependencies:
-    "@types/micro" "*"
-
-"@types/micro@*":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@types/micro/-/micro-7.3.3.tgz#31ead8df18ac10d58b7be1186d4b2d977b13a938"
-  integrity sha512-I3n3QYT7lqAxkyAoTZyg1yrvo38BxW/7ZafLAXZF/zZQOnAnQzg6j9XOuSmUEL5GGVFKWw4iqM+ZLnqb2154TA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -7812,11 +7798,6 @@ metro@0.59.0, metro@^0.59.0:
     xpipe "^1.0.5"
     yargs "^14.2.0"
 
-micro-cors@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/micro-cors/-/micro-cors-0.1.1.tgz#af7a480182c114ffd1ada84ad9dffc52bb4f4054"
-  integrity sha512-6WqIahA5sbQR1Gjexp1VuWGFDKbZZleJb/gy1khNGk18a6iN1FdTcr3Q8twaxkV5H94RjxIBjirYbWCehpMBFw==
-
 microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
@@ -11553,8 +11534,10 @@ watchpack@^1.6.1, watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
# Why

CORS is currently not working on the `/api/libraries` route (used in https://expo.io search). It seems that `micro-cors` just isn't working.

This PR fixes it by following the instructions for next.js: https://vercel.com/support/articles/how-to-enable-cors

It keeps the CORS settings that micro-cors was supposed to be setting.

# Repro

1. In Insomnia: GET https://reactnative.directory/api/libraries/?search=hello&expo=true, see no CORS headers returned.
2. In Chrome inspector, `await fetch('https://reactnative.directory/api/libraries/?search=hello&expo=true')`, see CORS error.

# Test Plan

1. `yarn start`
2. In Insomnia: GET http://localhost:3000/api/libraries/?search=hello&expo=true, see CORS headers returned.
3. In Chrome inspector, `await fetch('http://localhost:3000/api/libraries/?search=hello&expo=true')`, see JSON response.
