### PR TITLE
Add expo to react-native-progress

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -829,6 +829,7 @@
   {
     "githubUrl": "https://github.com/oblador/react-native-progress",
     "ios": true,
+    "expo": true,
     "android": true
   },
   {


### PR DESCRIPTION
# Why

Due to recent refactoring of the library it now supports expo. 
