### PR TITLE
init concept of the search "Relevance" sort option

### DIFF
--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -61,6 +61,9 @@ export default function Library(props: Props) {
           </View>
         ) : null}
         {showPopularity && library.popularity ? <PopularityMark library={library} /> : null}
+        {library.matchScore ? (
+          <Label style={{ color: colors.primary }}>Debug MatchScore: {library.matchScore}</Label>
+        ) : null}
         <View style={isSmallScreen ? styles.containerColumn : styles.displayHorizontal}>
           <A
             href={library.githubUrl || github.urls.repo}

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -61,9 +61,6 @@ export default function Library(props: Props) {
           </View>
         ) : null}
         {showPopularity && library.popularity ? <PopularityMark library={library} /> : null}
-        {library.matchScore ? (
-          <Label style={{ color: colors.primary }}>Debug MatchScore: {library.matchScore}</Label>
-        ) : null}
         <View style={isSmallScreen ? styles.containerColumn : styles.displayHorizontal}>
           <A
             href={library.githubUrl || github.urls.repo}

--- a/components/Sort.tsx
+++ b/components/Sort.tsx
@@ -15,6 +15,10 @@ type SortButtonProps = {
 
 const sorts = [
   {
+    param: 'relevance',
+    label: 'Relevance',
+  },
+  {
     param: 'updated',
     label: 'Last Updated',
   },
@@ -45,10 +49,6 @@ const sorts = [
   {
     param: 'stars',
     label: 'Stars',
-  },
-  {
-    param: 'relevance',
-    label: 'Relevance',
   },
 ];
 

--- a/components/Sort.tsx
+++ b/components/Sort.tsx
@@ -46,11 +46,15 @@ const sorts = [
     param: 'stars',
     label: 'Stars',
   },
+  {
+    param: 'relevance',
+    label: 'Relevance',
+  },
 ];
 
 export const SortButton = (props: SortButtonProps) => {
   const {
-    query: { order },
+    query: { order, search },
     query,
   } = props;
   const [sortValue, setSortValue] = useState(order || 'updated');
@@ -75,7 +79,7 @@ export const SortButton = (props: SortButtonProps) => {
       <View style={styles.pickerContainer}>
         <P style={styles.title}>
           <Picker
-            selectedValue={sortValue}
+            selectedValue={search && !order ? 'relevance' : sortValue}
             style={[
               styles.picker,
               {
@@ -83,7 +87,7 @@ export const SortButton = (props: SortButtonProps) => {
               },
             ]}
             onValueChange={onPickerChange}>
-            {sorts.map(sort => (
+            {(search ? sorts : sorts.filter(sort => sort.param !== 'relevance')).map(sort => (
               <Picker.Item
                 key={sort.param}
                 value={sort.param}

--- a/components/Sort.tsx
+++ b/components/Sort.tsx
@@ -54,10 +54,10 @@ const sorts = [
 
 export const SortButton = (props: SortButtonProps) => {
   const {
-    query: { order, search },
+    query: { order },
     query,
   } = props;
-  const [sortValue, setSortValue] = useState(order || 'updated');
+  const [sortValue, setSortValue] = useState(order || 'relevance');
   const { isDark } = useContext(CustomAppearanceContext);
 
   const onPickerChange = (order: QueryOrder) => {
@@ -79,7 +79,7 @@ export const SortButton = (props: SortButtonProps) => {
       <View style={styles.pickerContainer}>
         <P style={styles.title}>
           <Picker
-            selectedValue={search && !order ? 'relevance' : sortValue}
+            selectedValue={sortValue}
             style={[
               styles.picker,
               {
@@ -87,7 +87,7 @@ export const SortButton = (props: SortButtonProps) => {
               },
             ]}
             onValueChange={onPickerChange}>
-            {(search ? sorts : sorts.filter(sort => sort.param !== 'relevance')).map(sort => (
+            {sorts.map(sort => (
               <Picker.Item
                 key={sort.param}
                 value={sort.param}

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -70,7 +70,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const offset = req.query.offset ? parseInt(req.query.offset.toString(), 10) : 0;
   const limit = req.query.limit ? parseInt(req.query.limit.toString(), 10) : NUM_PER_PAGE;
 
-  const filteredAndPaginatedLibraries = take(drop(filteredLibraries, offset), limit);
+  const relevanceSortedLibraries =
+    querySearch?.length && (!req.query.order || req.query.order === 'relevance')
+      ? Sorting.relevance([...filteredLibraries])
+      : filteredLibraries;
+  const filteredAndPaginatedLibraries = take(drop(relevanceSortedLibraries, offset), limit);
+
   return res.end(
     JSON.stringify({
       libraries: filteredAndPaginatedLibraries,

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -71,7 +71,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const limit = req.query.limit ? parseInt(req.query.limit.toString(), 10) : NUM_PER_PAGE;
 
   const relevanceSortedLibraries =
-    querySearch?.length && req.query.order === 'relevance'
+    querySearch?.length && (!req.query.order || req.query.order === 'relevance')
       ? Sorting.relevance([...filteredLibraries])
       : filteredLibraries;
   const filteredAndPaginatedLibraries = take(drop(relevanceSortedLibraries, offset), limit);

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -71,7 +71,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const limit = req.query.limit ? parseInt(req.query.limit.toString(), 10) : NUM_PER_PAGE;
 
   const relevanceSortedLibraries =
-    querySearch?.length && (!req.query.order || req.query.order === 'relevance')
+    querySearch?.length && req.query.order === 'relevance'
       ? Sorting.relevance([...filteredLibraries])
       : filteredLibraries;
   const filteredAndPaginatedLibraries = take(drop(relevanceSortedLibraries, offset), limit);

--- a/types/index.ts
+++ b/types/index.ts
@@ -98,4 +98,5 @@ export type Library = {
   npmPkg?: string;
   nameOverride?: string;
   popularity: number;
+  matchScore?: number;
 };

--- a/util/search.js
+++ b/util/search.js
@@ -29,99 +29,101 @@ export const handleFilterLibraries = ({
   const viewerHasChosenTopic = !isEmptyOrNull(queryTopic);
   const viewerHasTypedSearch = !isEmptyOrNull(querySearch);
 
-  return libraries
-    .map(library => ({
-      ...library,
-      matchScore: viewerHasTypedSearch ? calculateMatchScore(library, querySearch) : undefined,
-    }))
-    .filter(library => {
-      let isTopicMatch = false;
-      let isSearchMatch = false;
+  const processedLibraries = viewerHasTypedSearch
+    ? libraries.map(library => ({
+        ...library,
+        matchScore: calculateMatchScore(library, querySearch),
+      }))
+    : libraries;
 
-      if (support.ios && !library.ios) {
-        return false;
-      }
+  return processedLibraries.filter(library => {
+    let isTopicMatch = false;
+    let isSearchMatch = false;
 
-      if (support.android && !library.android) {
-        return false;
-      }
+    if (support.ios && !library.ios) {
+      return false;
+    }
 
-      if (support.web && !library.web) {
-        return false;
-      }
+    if (support.android && !library.android) {
+      return false;
+    }
 
-      if (support.windows && !library.windows) {
-        return false;
-      }
+    if (support.web && !library.web) {
+      return false;
+    }
 
-      if (support.macos && !library.macos) {
-        return false;
-      }
+    if (support.windows && !library.windows) {
+      return false;
+    }
 
-      if (support.tvos && !library.tvos) {
-        return false;
-      }
+    if (support.macos && !library.macos) {
+      return false;
+    }
 
-      if (support.expo && !library.expo) {
-        return false;
-      }
+    if (support.tvos && !library.tvos) {
+      return false;
+    }
 
-      if (support.expo && typeof library.expo === 'string') {
-        return false;
-      }
+    if (support.expo && !library.expo) {
+      return false;
+    }
 
-      if (hasExample && (!library.examples || !library.examples.length)) {
-        return false;
-      }
+    if (support.expo && typeof library.expo === 'string') {
+      return false;
+    }
 
-      if (hasImage && (!library.images || !library.images.length)) {
-        return false;
-      }
+    if (hasExample && (!library.examples || !library.examples.length)) {
+      return false;
+    }
 
-      if (hasTypes && !library.github.hasTypes) {
-        return false;
-      }
+    if (hasImage && (!library.images || !library.images.length)) {
+      return false;
+    }
 
-      if (isMaintained && library.unmaintained) {
-        return false;
-      }
+    if (hasTypes && !library.github.hasTypes) {
+      return false;
+    }
 
-      if (isPopular && !library.matchingScoreModifiers.includes('Popular')) {
-        return false;
-      }
+    if (isMaintained && library.unmaintained) {
+      return false;
+    }
 
-      if (isRecommended && !library.matchingScoreModifiers.includes('Recommended')) {
-        return false;
-      }
+    if (isPopular && !library.matchingScoreModifiers.includes('Popular')) {
+      return false;
+    }
 
-      if (wasRecentlyUpdated && !library.matchingScoreModifiers.includes('Recently updated')) {
-        return false;
-      }
+    if (isRecommended && !library.matchingScoreModifiers.includes('Recommended')) {
+      return false;
+    }
 
-      if (minPopularity) {
-        return library.popularity * 100 >= parseFloat(minPopularity);
-      }
+    if (wasRecentlyUpdated && !library.matchingScoreModifiers.includes('Recently updated')) {
+      return false;
+    }
 
-      if (!viewerHasChosenTopic && !viewerHasTypedSearch) {
-        return true;
-      }
+    if (minPopularity) {
+      return library.popularity * 100 >= parseFloat(minPopularity);
+    }
 
-      if (viewerHasChosenTopic && library.topicSearchString.includes(queryTopic)) {
-        isTopicMatch = true;
-      }
+    if (!viewerHasChosenTopic && !viewerHasTypedSearch) {
+      return true;
+    }
 
-      if (!viewerHasTypedSearch) {
-        return isTopicMatch;
-      }
+    if (viewerHasChosenTopic && library.topicSearchString.includes(queryTopic)) {
+      isTopicMatch = true;
+    }
 
-      if (viewerHasTypedSearch) {
-        isSearchMatch = library.matchScore && library.matchScore > 0;
-      }
+    if (!viewerHasTypedSearch) {
+      return isTopicMatch;
+    }
 
-      if (!viewerHasChosenTopic) {
-        return isSearchMatch;
-      }
+    if (viewerHasTypedSearch) {
+      isSearchMatch = library.matchScore && library.matchScore > 0;
+    }
 
-      return isTopicMatch && isSearchMatch;
-    });
+    if (!viewerHasChosenTopic) {
+      return isSearchMatch;
+    }
+
+    return isTopicMatch && isSearchMatch;
+  });
 };

--- a/util/search.js
+++ b/util/search.js
@@ -9,7 +9,7 @@ const calculateMatchScore = ({ github, npmPkg, topicSearchString }, querySearch)
       ? 10
       : 0;
   const isTopicMatch = topicSearchString.includes(querySearch) ? 1 : 0;
-  return isNpmPkgNameMatch + isDescriptionMatch + isTopicMatch + isNameMatch;
+  return isNameMatch + isDescriptionMatch + isTopicMatch;
 };
 
 export const handleFilterLibraries = ({

--- a/util/sorting.js
+++ b/util/sorting.js
@@ -52,3 +52,7 @@ export const quality = libraries => {
 export const popularity = libraries => {
   return libraries.sort((a, b) => b.popularity - a.popularity);
 };
+
+export const relevance = libraries => {
+  return libraries.sort((a, b) => b.matchScore - a.matchScore);
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why & How

Lately we have received the feedback about the libraries order, when user have entered the search keyword. So far, we just retain the order no matter what libraries API query has been sent. However, this might be a bit confusing, because users might suspect that after using a `search` query the results "are refined" to promote the best matched results (via weight or some kind of score).

To address that, and as an effort to improved the UX this PR introduces the concept of "Relevance" - the dynamic sort order,  which only appears in the sort option, if user have entered a query. 

I have also implemented a basic, automatic switch, so when users enter a serach term, the sort order switches automatically to "Relevance" (if user have not set earlier the sort order manually). there is still a small issue, if the user manually select the "Relevance" sort and then removed the search query, data is display correctly, but "Relevance" retains as select item value.

Also the `matchScore` calculation at this point is very basic (+100 for name match, +10 for description match, +1 for keyword/tag match), but I would like to retain low level of logic complexity in there, because this sorting is dynamical and cannot be easy cached, like the other sorts are. All the "Relevance" entries are sorted first by `matchScore`, then, if score matches by the default sort, which is "Recently Updated".

I have also included the debug data (`matchScore` value) at the top of the library box, it's just a temporary addition, to make the testing of the feature easier.

Please provide the feedback and your opinion abut this new feature and the way it has been implemented, and please treat this PR as PoC, this feature might be rewritten or not even finally land in the production. 😉 

# Test deploy

- https://react-native-directory-7jall9sn0-rndir.vercel.app/

# Checklist

- [X] Documented in this PR how you fixed or created the feature.

CC: @satya164 
