### PR TITLE
update Snack domain in example links

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -235,7 +235,7 @@
   {
     "githubUrl": "https://github.com/Purii/react-native-tableview-simple",
     "examples": [
-      "https://snack.expo.io/@purii/react-native-tableview-simple",
+      "https://snack.expo.dev/@purii/react-native-tableview-simple",
       "https://github.com/Purii/react-native-tableview-simple/tree/master/example"
     ],
     "images": [
@@ -459,7 +459,7 @@
     "tvos": true,
     "goldstar": true,
     "examples": [
-      "https://snack.expo.io/rJnUK4nrZ",
+      "https://snack.expo.dev/rJnUK4nrZ",
       "https://github.com/dlowder-salesforce/ReactNavigationTVDemo",
       "https://github.com/react-native-tvos/TVReanimated"
     ]
@@ -505,7 +505,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/SJdIbHe4b"],
+    "examples": ["https://snack.expo.dev/SJdIbHe4b"],
     "goldstar": true
   },
   {
@@ -513,7 +513,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/H1zOFxnN-"],
+    "examples": ["https://snack.expo.dev/H1zOFxnN-"],
     "goldstar": true
   },
   {
@@ -521,7 +521,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/@bramus/react-native-maps-directions"]
+    "examples": ["https://snack.expo.dev/@bramus/react-native-maps-directions"]
   },
   {
     "githubUrl": "https://github.com/oblador/react-native-animatable",
@@ -529,14 +529,14 @@
     "android": true,
     "expo": true,
     "goldstar": true,
-    "examples": ["https://snack.expo.io/SJfJguhrW"]
+    "examples": ["https://snack.expo.dev/SJfJguhrW"]
   },
   {
     "githubUrl": "https://github.com/maggialejandro/react-native-calendario",
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/HyEN5150M"]
+    "examples": ["https://snack.expo.dev/HyEN5150M"]
   },
   {
     "githubUrl": "https://github.com/wix/react-native-calendars",
@@ -551,7 +551,7 @@
     "web": true,
     "expo": true,
     "goldstar": true,
-    "examples": ["https://snack.expo.io/HkoXUdhr-"]
+    "examples": ["https://snack.expo.dev/HkoXUdhr-"]
   },
   {
     "githubUrl": "https://github.com/oblador/react-native-vector-icons",
@@ -604,7 +604,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/SJIOAOUIb"]
+    "examples": ["https://snack.expo.dev/SJIOAOUIb"]
   },
   {
     "githubUrl": "https://github.com/maxs15/react-native-modalbox",
@@ -618,7 +618,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/ByBCD_2r-"]
+    "examples": ["https://snack.expo.dev/ByBCD_2r-"]
   },
   {
     "githubUrl": "https://github.com/react-native-elements/react-native-elements",
@@ -634,7 +634,7 @@
     "expo": true,
     "goldstar": true,
     "examples": [
-      "https://snack.expo.io/HJjbO4nSW",
+      "https://snack.expo.dev/HJjbO4nSW",
       "https://expo.io/@satya164/react-native-tab-view-demos",
       "https://github.com/satya164/react-native-tab-view/tree/main/example"
     ],
@@ -808,7 +808,7 @@
     "android": true,
     "expo": true,
     "unmaintained": true,
-    "examples": ["https://snack.expo.io/rkzzeFUIW"]
+    "examples": ["https://snack.expo.dev/rkzzeFUIW"]
   },
   {
     "githubUrl": "https://github.com/halilb/react-native-textinput-effects",
@@ -867,7 +867,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/SkRP2Ehrb"]
+    "examples": ["https://snack.expo.dev/SkRP2Ehrb"]
   },
   {
     "githubUrl": "https://github.com/obipawan/react-native-hyperlink",
@@ -915,7 +915,7 @@
   {
     "githubUrl": "https://github.com/leecade/react-native-swiper",
     "examples": [
-      "https://snack.expo.io/BkaD_dIL-",
+      "https://snack.expo.dev/BkaD_dIL-",
       "https://github.com/leecade/react-native-swiper/blob/master/examples/components/Basic",
       "https://github.com/leecade/react-native-swiper/blob/master/examples/components/Swiper"
     ],
@@ -961,7 +961,7 @@
     "android": true,
     "expo": true,
     "unmaintained": true,
-    "examples": ["https://snack.expo.io/HyQ25dU8Z"]
+    "examples": ["https://snack.expo.dev/HyQ25dU8Z"]
   },
   {
     "githubUrl": "https://github.com/appintheair/react-native-looped-carousel",
@@ -975,7 +975,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/rJpy3w3S-"]
+    "examples": ["https://snack.expo.dev/rJpy3w3S-"]
   },
   {
     "githubUrl": "https://github.com/xgfe/react-native-datepicker",
@@ -989,14 +989,14 @@
     "android": true,
     "expo": true,
     "web": true,
-    "examples": ["https://snack.expo.io/@sbell/react-native-google-places-autocomplete"]
+    "examples": ["https://snack.expo.dev/@sbell/react-native-google-places-autocomplete"]
   },
   {
     "githubUrl": "https://github.com/jeanregisser/react-native-slider",
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/H1cnedhBW"],
+    "examples": ["https://snack.expo.dev/H1cnedhBW"],
     "unmaintained": true
   },
   {
@@ -1004,14 +1004,14 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/rJ7q6PhSb"]
+    "examples": ["https://snack.expo.dev/rJ7q6PhSb"]
   },
   {
     "githubUrl": "https://github.com/halilb/react-native-photo-browser",
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/ryzXJOhH-"]
+    "examples": ["https://snack.expo.dev/ryzXJOhH-"]
   },
   {
     "githubUrl": "https://github.com/capitalone/react-native-pathjs-charts",
@@ -1032,7 +1032,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/rkjmEd3rZ"]
+    "examples": ["https://snack.expo.dev/rkjmEd3rZ"]
   },
   {
     "githubUrl": "https://github.com/FaridSafi/react-native-gifted-form",
@@ -1058,14 +1058,14 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/rkQrMFI8W"]
+    "examples": ["https://snack.expo.dev/rkQrMFI8W"]
   },
   {
     "githubUrl": "https://github.com/BugiDev/react-native-calendar-strip",
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/By-aQF8LZ"]
+    "examples": ["https://snack.expo.dev/By-aQF8LZ"]
   },
   {
     "githubUrl": "https://github.com/mohebifar/react-native-loader",
@@ -1084,7 +1084,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/Syd1a4hHW", "https://snack.expo.io/r1-cTNhH-"]
+    "examples": ["https://snack.expo.dev/Syd1a4hHW", "https://snack.expo.dev/r1-cTNhH-"]
   },
   {
     "githubUrl": "https://github.com/JackPu/react-native-percentage-circle",
@@ -1187,7 +1187,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/rJxdeFIIb"]
+    "examples": ["https://snack.expo.dev/rJxdeFIIb"]
   },
   {
     "githubUrl": "https://github.com/aksonov/react-native-tabs",
@@ -1200,14 +1200,14 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/S1QYWFILW"]
+    "examples": ["https://snack.expo.dev/S1QYWFILW"]
   },
   {
     "githubUrl": "https://github.com/ArnaudRinquin/react-native-radio-buttons",
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/Bk8-1FILb"],
+    "examples": ["https://snack.expo.dev/Bk8-1FILb"],
     "unmaintained": true
   },
   {
@@ -1295,7 +1295,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/rJBRhOLU-"]
+    "examples": ["https://snack.expo.dev/rJBRhOLU-"]
   },
   {
     "githubUrl": "https://github.com/d-a-n/react-native-webbrowser",
@@ -1515,7 +1515,7 @@
     "githubUrl": "https://github.com/naoufal/react-native-safari-view",
     "ios": true,
     "android": true,
-    "examples": ["https://snack.expo.io/r116LYJne?session_id=snack-session-rygins1kH-"]
+    "examples": ["https://snack.expo.dev/r116LYJne?session_id=snack-session-rygins1kH-"]
   },
   {
     "githubUrl": "https://github.com/fullstackreact/react-native-oauth",
@@ -1531,7 +1531,7 @@
   {
     "githubUrl": "https://github.com/terrillo/rn-apple-healthkit",
     "ios": true,
-    "examples": ["https://snack.expo.io/S1gdfOb4Z?session_id=snack-session-rypa21JSW"]
+    "examples": ["https://snack.expo.dev/S1gdfOb4Z?session_id=snack-session-rypa21JSW"]
   },
   {
     "githubUrl": "https://github.com/rt2zz/react-native-contacts",
@@ -2304,10 +2304,10 @@
     "expo": true,
     "web": true,
     "examples": [
-      "https://snack.expo.io/@gusgard/react-native-swiper-flatlist",
-      "https://snack.expo.io/@gusgard/react-native-swiper-flatlist-show-next-screen",
-      "https://snack.expo.io/@gusgard/react-native-swiper-flatlist-simple-with-renderitems-and-data",
-      "https://snack.expo.io/@gusgard/react-native-swiper-flatlist-simple-with-children"
+      "https://snack.expo.dev/@gusgard/react-native-swiper-flatlist",
+      "https://snack.expo.dev/@gusgard/react-native-swiper-flatlist-show-next-screen",
+      "https://snack.expo.dev/@gusgard/react-native-swiper-flatlist-simple-with-renderitems-and-data",
+      "https://snack.expo.dev/@gusgard/react-native-swiper-flatlist-simple-with-children"
     ]
   },
   {
@@ -2315,7 +2315,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/@gusgard/react-native-grid-list"]
+    "examples": ["https://snack.expo.dev/@gusgard/react-native-grid-list"]
   },
   {
     "githubUrl": "https://github.com/JimmyDaddy/react-native-image-marker",
@@ -2366,7 +2366,7 @@
   },
   {
     "githubUrl": "https://github.com/ardaogulcan/react-native-keyboard-accessory",
-    "examples": ["https://snack.expo.io/@ardaogulcan/react-native-keyboard-accessory-playground"],
+    "examples": ["https://snack.expo.dev/@ardaogulcan/react-native-keyboard-accessory-playground"],
     "images": [
       "https://media.giphy.com/media/ZFh86727hAbAc/giphy.gif",
       "https://media.giphy.com/media/NYsR2BtQaUaQw/giphy.gif"
@@ -2996,7 +2996,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/@mxmzb/react-native-gesture-detector"]
+    "examples": ["https://snack.expo.dev/@mxmzb/react-native-gesture-detector"]
   },
   {
     "githubUrl": "https://github.com/n4kz/react-native-indicators",
@@ -3198,7 +3198,7 @@
     "android": true,
     "expo": true,
     "examples": [
-      "https://snack.expo.io/@tienph6m/react-native-animated-spinkit",
+      "https://snack.expo.dev/@tienph6m/react-native-animated-spinkit",
       "https://github.com/tienph6m/react-native-animated-spinkit/tree/master/example"
     ],
     "images": [
@@ -3225,7 +3225,7 @@
     "android": true,
     "expo": true,
     "web": true,
-    "examples": ["https://snack.expo.io/@seniv/react-native-notifer-example"]
+    "examples": ["https://snack.expo.dev/@seniv/react-native-notifer-example"]
   },
   {
     "githubUrl": "https://github.com/react-ui-kit/expo-ui-kit",
@@ -3552,7 +3552,7 @@
   },
   {
     "githubUrl": "https://github.com/wKovacs64/react-native-responsive-image-view",
-    "examples": ["https://snack.expo.io/@wkovacs64/responsiveimageview"],
+    "examples": ["https://snack.expo.dev/@wkovacs64/responsiveimageview"],
     "ios": true,
     "android": true,
     "expo": true
@@ -3597,7 +3597,7 @@
     "web": true,
     "expo": true,
     "examples": [
-      "https://snack.expo.io/@xcarpentier/giftedchat-playground",
+      "https://snack.expo.dev/@xcarpentier/giftedchat-playground",
       "https://reverent-bardeen-47c862.netlify.app/"
     ],
     "images": ["https://thumbs.gfycat.com/AbsoluteSadDobermanpinscher-size_restricted.gif"]
@@ -3693,7 +3693,7 @@
     "expo": true,
     "tvos": true,
     "web": true,
-    "examples": ["https://snack.expo.io/@msand/react-native-svg-example"]
+    "examples": ["https://snack.expo.dev/@msand/react-native-svg-example"]
   },
   {
     "githubUrl": "https://github.com/dooboolab/react-native-iap",
@@ -3868,7 +3868,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/@mxck/react-native-material-menu-demo"]
+    "examples": ["https://snack.expo.dev/@mxck/react-native-material-menu-demo"]
   },
   {
     "githubUrl": "https://github.com/jacklam718/react-native-modals",
@@ -4175,7 +4175,7 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/BypG26zdz"]
+    "examples": ["https://snack.expo.dev/BypG26zdz"]
   },
   {
     "githubUrl": "https://github.com/wkh237/react-native-fetch-blob",
@@ -4269,7 +4269,7 @@
   {
     "githubUrl": "https://github.com/jemise111/react-native-swipe-list-view",
     "images": ["https://media.giphy.com/media/WrmrvmwMnvvmzN3ZpX/giphy.gif"],
-    "examples": ["https://snack.expo.io/@jemise111/react-native-swipe-list-view"],
+    "examples": ["https://snack.expo.dev/@jemise111/react-native-swipe-list-view"],
     "ios": true,
     "android": true,
     "expo": true
@@ -4341,9 +4341,9 @@
     "web": true,
     "expo": true,
     "examples": [
-      "https://snack.expo.io/@naqvitalha/rlv-demo",
-      "https://snack.expo.io/B1GYad52b",
-      "https://snack.expo.io/@arunreddy10/19bb8e"
+      "https://snack.expo.dev/@naqvitalha/rlv-demo",
+      "https://snack.expo.dev/B1GYad52b",
+      "https://snack.expo.dev/@arunreddy10/19bb8e"
     ]
   },
   {
@@ -4702,7 +4702,7 @@
   {
     "githubUrl": "https://github.com/thodubois/react-native-woodpicker",
     "examples": [
-      "https://snack.expo.io/@fromwood/react-native-woodpicker-example",
+      "https://snack.expo.dev/@fromwood/react-native-woodpicker-example",
       "https://github.com/thodubois/react-native-woodpicker/tree/master/ExampleApp"
     ],
     "images": [
@@ -4784,7 +4784,7 @@
     "githubUrl": "https://github.com/sospedra/reinput",
     "examples": [
       "https://github.com/sospedra/reinput/tree/master/example",
-      "https://snack.expo.io/@git/github.com/sospedra/reinput:example"
+      "https://snack.expo.dev/@git/github.com/sospedra/reinput:example"
     ],
     "images": [
       "https://user-images.githubusercontent.com/3116899/84693731-3d597380-af48-11ea-8614-b549211f5015.png"
@@ -4950,7 +4950,7 @@
     "githubUrl": "https://github.com/colorfy-software/react-native-modalfy",
     "examples": [
       "https://github.com/colorfy-software/react-native-modalfy/tree/master/Example",
-      "https://snack.expo.io/@charles.m/react-native-modalfy"
+      "https://snack.expo.dev/@charles.m/react-native-modalfy"
     ],
     "images": [
       "https://i.imgur.com/q8QFajL.gif",
@@ -5183,7 +5183,7 @@
   {
     "githubUrl": "https://github.com/retyui/react-native-confirmation-code-field",
     "examples": [
-      "https://snack.expo.io/Zil!jCFft",
+      "https://snack.expo.dev/Zil!jCFft",
       "https://github.com/retyui/react-native-confirmation-code-field/tree/master/examples/DemoCodeField"
     ],
     "images": [
@@ -5354,7 +5354,7 @@
     "githubUrl": "https://github.com/vydimitrov/use-count-up",
     "examples": [
       "https://use-count-up.now.sh/",
-      "https://snack.expo.io/@vydimitrov/use-count-up?platform=ios"
+      "https://snack.expo.dev/@vydimitrov/use-count-up?platform=ios"
     ],
     "images": [
       "https://user-images.githubusercontent.com/10707142/82188777-ac628e80-98ee-11ea-8a10-0469713a3bbc.gif"
@@ -5369,7 +5369,7 @@
   {
     "githubUrl": "https://github.com/vydimitrov/react-countdown-circle-timer/tree/master/packages/mobile",
     "npmPkg": "react-native-countdown-circle-timer",
-    "examples": ["https://snack.expo.io/@vydimitrov/countdown-circle-timer?platform=ios"],
+    "examples": ["https://snack.expo.dev/@vydimitrov/countdown-circle-timer?platform=ios"],
     "images": [
       "https://user-images.githubusercontent.com/10707142/66097204-ca68c200-e59d-11e9-9b70-688409755aaa.gif",
       "https://user-images.githubusercontent.com/10707142/65935516-a0869280-e419-11e9-9bb0-40c4d1ef2bbe.gif",
@@ -5556,7 +5556,7 @@
   {
     "githubUrl": "https://github.com/storybookjs/react-native",
     "npmPkg": "@storybook/react-native",
-    "examples": ["https://snack.expo.io/@dannyhw/expo-storybook-example"],
+    "examples": ["https://snack.expo.dev/@dannyhw/expo-storybook-example"],
     "ios": true,
     "android": true,
     "web": true,
@@ -6027,7 +6027,7 @@
   },
   {
     "githubUrl": "https://github.com/dstaley/react-native-bootstrap-icons",
-    "examples": ["https://snack.expo.io/@dstaley/react-native-bootstrap-icons"],
+    "examples": ["https://snack.expo.dev/@dstaley/react-native-bootstrap-icons"],
     "ios": true,
     "android": true,
     "web": true,
@@ -6093,6 +6093,7 @@
   },
   {
     "githubUrl": "https://github.com/react-hook-form/react-hook-form",
+    "examples": ["https://snack.expo.dev/@bluebill1049/react-hook-form"],
     "ios": true,
     "web": true,
     "android": true,
@@ -6120,7 +6121,7 @@
   },
   {
     "githubUrl": "https://github.com/carloscuesta/react-native-error-boundary",
-    "examples": ["https://snack.expo.io/@carloscuesta/react-native-error-boundary"],
+    "examples": ["https://snack.expo.dev/@carloscuesta/react-native-error-boundary"],
     "images": [
       "https://user-images.githubusercontent.com/7629661/52532748-d8758400-2d29-11e9-80a0-15182517271c.gif",
       "https://user-images.githubusercontent.com/7629661/106904482-89d20900-66fb-11eb-80ed-71b95ebd9120.png"
@@ -6131,7 +6132,7 @@
   },
   {
     "githubUrl": "https://github.com/OsmiCSX/osmicsx",
-    "examples": ["https://snack.expo.io/@devoresyah/osmiprovider-example"],
+    "examples": ["https://snack.expo.dev/@devoresyah/osmiprovider-example"],
     "ios": true,
     "android": true,
     "expo": true
@@ -6246,7 +6247,7 @@
   },
   {
     "githubUrl": "https://github.com/dabakovich/react-native-controlled-mentions",
-    "examples": ["https://snack.expo.io/@dabakovich/mentionsapp"],
+    "examples": ["https://snack.expo.dev/@dabakovich/mentionsapp"],
     "images": [
       "https://raw.githubusercontent.com/dabakovich/react-native-controlled-mentions/master/demo.gif"
     ],
@@ -6420,7 +6421,7 @@
   },
   {
     "githubUrl": "https://github.com/reactrondev/react-native-web-swiper",
-    "examples": ["https://snack.expo.io/@oxyii/react-native-web-swiper"],
+    "examples": ["https://snack.expo.dev/@oxyii/react-native-web-swiper"],
     "android": true,
     "ios": true,
     "web": true,
@@ -6677,7 +6678,7 @@
   },
   {
     "githubUrl": "https://github.com/fram-x/react-native-styled-text",
-    "examples": ["https://snack.expo.io/@bjornegil/styledtext-demo"],
+    "examples": ["https://snack.expo.dev/@bjornegil/styledtext-demo"],
     "images": [
       "https://raw.githubusercontent.com/fram-x/react-native-styled-text/develop/docs/example-ios.png",
       "https://raw.githubusercontent.com/fram-x/react-native-styled-text/develop/docs/example-android.png"
@@ -6764,7 +6765,7 @@
     "nameOverride": "SVGR IconKit",
     "examples": [
       "https://svgr-iconkit.dev/expo-explorer/",
-      "https://snack.expo.io/@lemankk/svgr-iconkit-sample-with-material-design-icons",
+      "https://snack.expo.dev/@lemankk/svgr-iconkit-sample-with-material-design-icons",
       "https://svgr-iconkit.dev/explorer"
     ],
     "ios": true,
@@ -6776,7 +6777,7 @@
     "githubUrl": "https://github.com/akinncar/react-native-mask-text",
     "examples": [
       "https://github.com/akinncar/react-native-mask-text/tree/main/example",
-      "https://snack.expo.io/@akinncar/react-native-mask-text"
+      "https://snack.expo.dev/@akinncar/react-native-mask-text"
     ],
     "ios": true,
     "android": true,
@@ -6843,7 +6844,7 @@
   },
   {
     "githubUrl": "https://github.com/rdhox/react-native-smooth-picker",
-    "examples": ["https://snack.expo.io/@rdhox/smoothpicker"],
+    "examples": ["https://snack.expo.dev/@rdhox/smoothpicker"],
     "images": [
       "https://raw.githubusercontent.com/rdhox/react-native-smooth-picker/master/assets/demo.gif"
     ],
@@ -6918,7 +6919,9 @@
   {
     "githubUrl": "https://github.com/ximxim/react-native-feedback-reporter",
     "examples": ["https://github.com/ximxim/react-native-feedback-reporter/tree/main/example"],
-    "images": ["https://ximxim.github.io/react-native-feedback-reporter/img/jira-account-linking.gif"],
+    "images": [
+      "https://ximxim.github.io/react-native-feedback-reporter/img/jira-account-linking.gif"
+    ],
     "ios": true,
     "android": true
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Expo has made a switch from `io` to `dev` domains:
* https://blog.expo.dev/introducing-expo-dev-a70818bf336e

# How

This PR replaces all the `snack.expo.io` entries in libraries examples with `snack.expo.dev`.
