### PR TITLE
remove react-native-linkedin - repo returns 404

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -2112,12 +2112,6 @@
     "unmaintained": true
   },
   {
-    "githubUrl": "https://github.com/xcarpentier/react-native-linkedin",
-    "ios": true,
-    "android": true,
-    "expo": true
-  },
-  {
     "githubUrl": "https://github.com/peggyrayzis/react-native-create-bridge",
     "ios": true,
     "android": true


### PR DESCRIPTION
# Why

This PR removes the `react-native-linkedin` package because its repo no longer exist or has been converted to private (which I have spotted in deploy logs):
* https://github.com/xcarpentier/react-native-linkedin

