### PR TITLE
extract few components, fix few Next warnings

### DIFF
--- a/components/ContentContainer.tsx
+++ b/components/ContentContainer.tsx
@@ -1,17 +1,11 @@
-import React, { ReactNode } from 'react';
-import { View, StyleSheet, ViewStyle } from 'react-native';
+import React, { PropsWithChildren } from 'react';
+import { View, ViewProps, StyleSheet } from 'react-native';
 
 import { layout } from '../common/styleguide';
 
-type Props = {
-  children: ReactNode;
-  style?: ViewStyle | ViewStyle[];
-};
-
-export default function ContentContainer(props: Props) {
-  const { children, style } = props;
-  return <View style={[styles.container, style]}>{children}</View>;
-}
+const ContentContainer = ({ children, style }: PropsWithChildren<ViewProps>) => (
+  <View style={[styles.container, style]}>{children}</View>
+);
 
 const styles = StyleSheet.create({
   container: {
@@ -21,3 +15,5 @@ const styles = StyleSheet.create({
     margin: 'auto',
   },
 });
+
+export default ContentContainer;

--- a/components/ErrorState.tsx
+++ b/components/ErrorState.tsx
@@ -3,7 +3,7 @@ import { Image, StyleSheet, View } from 'react-native';
 
 import { H2, A, P } from '../common/styleguide';
 
-export default ({ statusCode }) => {
+const ErrorState = ({ statusCode }) => {
   return (
     <View style={styles.container}>
       <Image style={styles.img} source={require('../assets/notfound.png')} />
@@ -37,3 +37,5 @@ const styles = StyleSheet.create({
     marginTop: 20,
   },
 });
+
+export default ErrorState;

--- a/components/GoogleAnalytics.tsx
+++ b/components/GoogleAnalytics.tsx
@@ -11,7 +11,8 @@ ga('send', 'pageview');
 `.replace(/\n/g, '');
 };
 
-export default function GoogleAnalytics({ id }) {
-  const markup = { __html: getAnalyticsScript(id) };
-  return <script dangerouslySetInnerHTML={markup} />;
-}
+const GoogleAnalytics = ({ id }) => (
+  <script dangerouslySetInnerHTML={{ __html: getAnalyticsScript(id) }} />
+);
+
+export default GoogleAnalytics;

--- a/components/Libraries.tsx
+++ b/components/Libraries.tsx
@@ -14,9 +14,7 @@ const LibraryWithLoading = dynamic(() => import('../components/Library'), {
   loading: () => <LoadingContent />,
 });
 
-export default function Libraries(props: Props) {
-  const { libraries } = props;
-
+const Libraries = ({ libraries }: Props) => {
   if (!libraries || !libraries.length) {
     return (
       <View style={styles.container}>
@@ -39,7 +37,7 @@ export default function Libraries(props: Props) {
       ))}
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -62,3 +60,5 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
+
+export default Libraries;

--- a/components/Library/RecommendedLabel.tsx
+++ b/components/Library/RecommendedLabel.tsx
@@ -1,0 +1,57 @@
+import React, { useContext } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { colors, darkColors, Label } from '../../common/styleguide';
+import CustomAppearanceContext from '../../context/CustomAppearanceContext';
+import { Badge } from '../Icons';
+
+const RecommendedLabel = ({ isSmallScreen }) => {
+  const { isDark } = useContext(CustomAppearanceContext);
+  return (
+    <View
+      style={[
+        styles.recommendedContainer,
+        isSmallScreen ? styles.recommendedContainerSmall : null,
+        {
+          backgroundColor: isDark ? colors.primaryDark : colors.primaryLight,
+        },
+      ]}>
+      <View style={styles.recommendedTextContainer}>
+        <Badge width={11} height={16} />
+        <Label
+          style={[
+            styles.recommendedText,
+            {
+              color: isDark ? darkColors.dark : colors.black,
+            },
+          ]}>
+          Recommended Library
+        </Label>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  recommendedContainer: {
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 2,
+    marginLeft: 10,
+    top: 1,
+  },
+  recommendedContainerSmall: {
+    marginLeft: 0,
+    marginTop: 8,
+    alignSelf: 'flex-start',
+  },
+  recommendedTextContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  recommendedText: {
+    marginLeft: 6,
+  },
+});
+
+export default RecommendedLabel;

--- a/components/Library/Thumbnail.tsx
+++ b/components/Library/Thumbnail.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useContext, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ActivityIndicator } from 'react-native';
+import { ActivityIndicator, StyleSheet } from 'react-native';
 import { usePopper } from 'react-popper';
 
 import { colors, darkColors } from '../../common/styleguide';
@@ -19,7 +19,7 @@ const Thumbnail = ({ url }: Props) => {
   const previewRef = useRef();
 
   const { styles, attributes } = usePopper(iconRef.current, previewRef.current, {
-    placement: 'bottom-end',
+    placement: 'bottom',
     strategy: 'fixed',
   });
 
@@ -60,7 +60,7 @@ const Thumbnail = ({ url }: Props) => {
           {showPreview && (
             <div className={'preview' + (isLoaded ? ' loaded' : '')}>
               {isLoaded ? null : <ActivityIndicator size="small" />}
-              <img src={url} onLoad={() => setLoaded(true)} alt="" />
+              <img src={url} onLoad={() => setLoaded(true)} alt="" style={{ maxHeight: 600 }} />
             </div>
           )}
         </div>,

--- a/components/Library/UnmaintainedLabel.tsx
+++ b/components/Library/UnmaintainedLabel.tsx
@@ -1,0 +1,54 @@
+import React, { useContext } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { colors, darkColors, Label } from '../../common/styleguide';
+import CustomAppearanceContext from '../../context/CustomAppearanceContext';
+import { Warning } from '../Icons';
+
+const UnmaintainedLabel = () => {
+  const { isDark } = useContext(CustomAppearanceContext);
+  return (
+    <View style={styles.unmaintainedTextWrapper}>
+      <View
+        style={[
+          styles.unmaintainedTextContainer,
+          {
+            backgroundColor: isDark ? darkColors.warning : colors.warningLight,
+          },
+        ]}>
+        <Warning width={16} height={16} fill={isDark ? colors.gray2 : colors.warningDark} />
+        <Label
+          style={[
+            styles.unmaintainedText,
+            {
+              color: isDark ? colors.gray2 : colors.warningDark,
+            },
+          ]}>
+          This library is not actively maintained
+        </Label>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  unmaintainedTextWrapper: {
+    flexDirection: 'row',
+  },
+  unmaintainedTextContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginLeft: -20,
+    marginBottom: 12,
+    paddingLeft: 20,
+    paddingRight: 12,
+    paddingVertical: 6,
+    borderTopRightRadius: 2,
+    borderBottomRightRadius: 2,
+  },
+  unmaintainedText: {
+    marginLeft: 6,
+  },
+});
+
+export default UnmaintainedLabel;

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -3,15 +3,16 @@ import React, { useContext } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import Linkify from 'react-simple-linkify';
 
-import { colors, useLayout, A, Label, Caption, darkColors } from '../../common/styleguide';
+import { colors, useLayout, A, Caption, darkColors } from '../../common/styleguide';
 import CustomAppearanceContext from '../../context/CustomAppearanceContext';
 import { Library as LibraryType } from '../../types';
 import { isEmptyOrNull } from '../../util/strings';
 import { CompatibilityTags } from '../CompatibilityTags';
-import { Badge, Warning } from '../Icons';
 import { MetaData } from './MetaData';
 import PopularityMark from './PopularityMark';
+import RecommendedLabel from './RecommendedLabel';
 import Thumbnail from './Thumbnail';
+import UnmaintainedLabel from './UnmaintainedLabel';
 
 type Props = {
   library: LibraryType;
@@ -19,9 +20,8 @@ type Props = {
   showPopularity?: boolean;
 };
 
-export default function Library(props: Props) {
+const Library = ({ library, skipMeta, showPopularity }: Props) => {
   const { isDark } = useContext(CustomAppearanceContext);
-  const { library, skipMeta, showPopularity } = props;
   const { github } = library;
   const { isSmallScreen, isBelowMaxWidth } = useLayout();
   const libName = library.nameOverride || library.npmPkg || github.name;
@@ -38,28 +38,7 @@ export default function Library(props: Props) {
         skipMeta && (isSmallScreen || isBelowMaxWidth) && styles.noMetaColumnContainer,
       ]}>
       <View style={styles.columnOne}>
-        {library.unmaintained ? (
-          <View style={styles.unmaintainedTextWrapper}>
-            <View
-              style={[
-                styles.unmaintainedTextContainer,
-                {
-                  backgroundColor: isDark ? darkColors.warning : colors.warningLight,
-                },
-              ]}>
-              <Warning width={16} height={16} fill={isDark ? colors.gray2 : colors.warningDark} />
-              <Label
-                style={[
-                  styles.unmaintainedText,
-                  {
-                    color: isDark ? colors.gray2 : colors.warningDark,
-                  },
-                ]}>
-                This library is not actively maintained
-              </Label>
-            </View>
-          </View>
-        ) : null}
+        {library.unmaintained ? <UnmaintainedLabel /> : null}
         {showPopularity && library.popularity ? <PopularityMark library={library} /> : null}
         <View style={isSmallScreen ? styles.containerColumn : styles.displayHorizontal}>
           <A
@@ -68,29 +47,7 @@ export default function Library(props: Props) {
             hoverStyle={styles.nameHovered}>
             {libName}
           </A>
-          {library.goldstar && (
-            <View
-              style={[
-                styles.recommendedContainer,
-                isSmallScreen ? styles.recommendedContainerSmall : null,
-                {
-                  backgroundColor: isDark ? colors.primaryDark : colors.primaryLight,
-                },
-              ]}>
-              <View style={styles.recommendedTextContainer}>
-                <Badge width={11} height={16} />
-                <Label
-                  style={[
-                    styles.recommendedText,
-                    {
-                      color: isDark ? darkColors.dark : colors.black,
-                    },
-                  ]}>
-                  Recommended Library
-                </Label>
-              </View>
-            </View>
-          )}
+          {library.goldstar && <RecommendedLabel isSmallScreen={isSmallScreen} />}
         </View>
         <View style={styles.verticalMargin}>
           <CompatibilityTags library={library} />
@@ -141,9 +98,9 @@ export default function Library(props: Props) {
       )}
     </View>
   );
-}
+};
 
-let styles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     marginBottom: 16,
     borderWidth: 1,
@@ -212,23 +169,6 @@ let styles = StyleSheet.create({
   recommendedText: {
     marginLeft: 6,
   },
-  unmaintainedTextWrapper: {
-    flexDirection: 'row',
-  },
-  unmaintainedTextContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginLeft: -20,
-    marginBottom: 12,
-    paddingLeft: 20,
-    paddingRight: 12,
-    paddingVertical: 6,
-    borderTopRightRadius: 2,
-    borderBottomRightRadius: 2,
-  },
-  unmaintainedText: {
-    marginLeft: 6,
-  },
   verticalMargin: {
     marginTop: 12,
   },
@@ -276,3 +216,5 @@ let styles = StyleSheet.create({
     maxWidth: '98.5%',
   },
 });
+
+export default Library;

--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -16,7 +16,7 @@ type Props = {
   style?: ViewStyle;
 };
 
-export default function Pagination(props: Props) {
+const Pagination = (props: Props) => {
   const { isDark } = useContext(CustomAppearanceContext);
   const { query, total, style } = props;
   const totalPages = Math.ceil(total / NUM_PER_PAGE);
@@ -81,7 +81,7 @@ export default function Pagination(props: Props) {
       )}
     </View>
   );
-}
+};
 
 let styles = StyleSheet.create({
   container: {
@@ -109,3 +109,5 @@ let styles = StyleSheet.create({
     marginHorizontal: 6,
   },
 });
+
+export default Pagination;

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -16,7 +16,7 @@ type Props = {
   total: number;
 };
 
-export default function Search(props: Props) {
+const Search = (props: Props) => {
   const { query, total } = props;
   const [isFilterVisible, setFilterVisible] = useState(false);
   const callback = useDebouncedCallback((text: string) => {
@@ -79,7 +79,7 @@ export default function Search(props: Props) {
       {isFilterVisible && <Filters query={query} />}
     </>
   );
-}
+};
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -130,3 +130,5 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
 });
+
+export default Search;

--- a/context/CustomAppearanceProvider.tsx
+++ b/context/CustomAppearanceProvider.tsx
@@ -10,7 +10,7 @@ const shouldRehydrate = true;
 
 const defaultState = { isDark: false };
 
-export default function CustomAppearanceProvider({ children }) {
+const CustomAppearanceProvider = ({ children }) => {
   const colorScheme = useColorScheme();
   const [isDark, setIsDark] = React.useState(colorScheme === 'dark');
   const [isLoaded, setLoaded] = React.useState(false);
@@ -47,7 +47,7 @@ export default function CustomAppearanceProvider({ children }) {
       </CustomAppearanceContext.Provider>
     );
   }
-}
+};
 
 async function cacheAppearanceState(appearance) {
   await AsyncStorage.setItem(appearanceStorageKey, JSON.stringify(appearance));
@@ -65,3 +65,5 @@ async function rehydrateAppearanceState() {
     return defaultState;
   }
 }
+
+export default CustomAppearanceProvider;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This PR extract few Library components to the separate files to improve the code readability.

Within this PR I have also added the max height for the images in popper (set to `600px`) to prevent very big screenshots to cover significant portion of the screen or always overflows beyond the viewport.

# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
