### PR TITLE
set match score to `0` for unmaintained libraries

### DIFF
--- a/util/search.js
+++ b/util/search.js
@@ -1,6 +1,9 @@
 import { isEmptyOrNull } from './strings';
 
-const calculateMatchScore = ({ github, npmPkg, topicSearchString }, querySearch) => {
+const calculateMatchScore = ({ github, npmPkg, topicSearchString, unmaintained }, querySearch) => {
+  if (unmaintained) {
+    return 0;
+  }
   const isRepoNameMatch = !isEmptyOrNull(github.name) && github.name.includes(querySearch);
   const isNpmPkgNameMatch = !isEmptyOrNull(npmPkg) && npmPkg.includes(querySearch);
   const isNameMatch = isRepoNameMatch || isNpmPkgNameMatch ? 100 : 0;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 👍 We appreciate you spending the time to work on these changes. -->
<!-- Please follow the template so that the reviewers can easily understand what the code changes affect. -->

# 📝 Why & how

Currently library match score was not affected by the `unmaintained` status, which leads to search result for some keywords promoting the outdated packages, for example:
* https://reactnative.directory/?search=gestures
* https://reactnative.directory/?search=accordion

This PR adds a check which will assign `0` as the match score, so the library still will be on the results list, but it will be placed at the end of the list.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X] -->

- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
