### PR TITLE
use Node 14 in all CI workflows

### DIFF
--- a/.github/workflows/test-and-validate.yml
+++ b/.github/workflows/test-and-validate.yml
@@ -5,13 +5,12 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ~12.16.3
-      uses: actions/setup-node@v1
+    - name: Use Node.js 14
+      uses: actions/setup-node@v2
       with:
-        node-version: '~12.16.3'
+        node-version: '14'
     - name: Install dependencies
       run: yarn
     - name: Lint


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

Currently only `Test and Validate` workflow uses Node 12, both other workflows uses Node 14 and `v2` of `setup-node` action.

Let's use the same version of Node and `setup-node` action in all workflows! 😉 

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
