### PR TITLE
change unmaintained libraries search scoring

### DIFF
--- a/util/search.js
+++ b/util/search.js
@@ -1,9 +1,6 @@
 import { isEmptyOrNull } from './strings';
 
 const calculateMatchScore = ({ github, npmPkg, topicSearchString, unmaintained }, querySearch) => {
-  if (unmaintained) {
-    return 0;
-  }
   const isRepoNameMatch = !isEmptyOrNull(github.name) && github.name.includes(querySearch);
   const isNpmPkgNameMatch = !isEmptyOrNull(npmPkg) && npmPkg.includes(querySearch);
   const isNameMatch = isRepoNameMatch || isNpmPkgNameMatch ? 100 : 0;
@@ -12,7 +9,12 @@ const calculateMatchScore = ({ github, npmPkg, topicSearchString, unmaintained }
       ? 10
       : 0;
   const isTopicMatch = topicSearchString.includes(querySearch) ? 1 : 0;
-  return isNameMatch + isDescriptionMatch + isTopicMatch;
+  const matchScore = isNameMatch + isDescriptionMatch + isTopicMatch;
+  if (matchScore && unmaintained) {
+    return matchScore / 1000;
+  } else {
+    return matchScore;
+  }
 };
 
 export const handleFilterLibraries = ({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

After latest change it looks like `unmaintaned` libraries are not showing up in the serach results.

This PR fixes that issue and also ensures that `unmaintaned` libraries will be at the end of the list and they will still be ordered in the correct way, corresponding to their base match score.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [X] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
