### PR TITLE
Add react-native-payment-icons

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -7656,5 +7656,14 @@
     ],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/SrBrahma/react-native-payment-icons",
+    "images": [
+      "https://github.com/SrBrahma/react-native-payment-icons/raw/main/resources/example.jpg"
+    ],
+    "ios": true,
+    "android": true,
+    "expo": true
   }
 ]


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

It adds my new package I created yesterday. Here it's its description:

"There wasn't a package for displaying credit cards and other payment methods icons in React Native. Wasn't!

We use SVGs that were transormed into React Native JSX, so there isn't a loading time to show them up.

The SVGs are compressed / optimized by ~60%. It uses the Flat Rounded images from aaronfagan/svg-credit-card-payment-icons, and I intend to support other icon packs in the future, in a tree-shakable way.

If you need to discover the card type (visa, mastercard etc), you can use the credit-card-type package."

https://github.com/SrBrahma/react-native-payment-icons

<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [X] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
