### PR TITLE
add watchers stat, add link to stargazers

### DIFF
--- a/components/Icons/index.tsx
+++ b/components/Icons/index.tsx
@@ -173,6 +173,18 @@ export function Issue(props: Props) {
   );
 }
 
+export function Eye(props: Props) {
+  const { width, height, fill = colors.black } = props;
+  return (
+    <Svg width={width || 22} height={height || 22} viewBox="0 0 24 24" fill="none">
+      <Path
+        fill={fill}
+        d="M11.9,7.1c4.6,0,7.8,2.9,9.2,4.5c-1.4,1.8-4.6,5.2-9.2,5.2c-4.3,0-7.7-3.4-9.2-5.3C4.1,10,7.3,7.1,11.9,7.1z M12,5 C4.4,5,0,11.6,0,11.6S4.8,19,12,19c7.7,0,12-7.4,12-7.4S19.7,5,12,5z M11.9,8.5c-1.9,0-3.5,1.6-3.5,3.5s1.6,3.5,3.5,3.5 c1.9,0,3.5-1.6,3.5-3.5S13.8,8.5,11.9,8.5z M11.9,12c-0.5,0.5-1.3,0.5-1.8,0c-0.5-0.5-0.5-1.3,0-1.8c0.5-0.5,1.3-0.5,1.8,0 C12.4,10.7,12.4,11.5,11.9,12z"
+      />
+    </Svg>
+  );
+}
+
 export function Logo(props: Props) {
   const { width, height, fill = colors.black } = props;
   return (

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -5,7 +5,18 @@ import { colors, A, P, Caption, darkColors } from '../../common/styleguide';
 import CustomAppearanceContext from '../../context/CustomAppearanceContext';
 import { Library as LibraryType } from '../../types';
 import { getTimeSinceToday } from '../../util/datetime';
-import { Calendar, Star, Download, Issue, Web, License, Fork, Code, TypeScript } from '../Icons';
+import {
+  Calendar,
+  Star,
+  Download,
+  Eye,
+  Issue,
+  Web,
+  License,
+  Fork,
+  Code,
+  TypeScript,
+} from '../Icons';
 import { DirectoryScore } from './DirectoryScore';
 
 type Props = {
@@ -115,7 +126,11 @@ const generateData = (library, secondary, isDark) => {
       {
         id: 'star',
         icon: <Star fill={iconColor} />,
-        content: <Caption>{github.stats.stars.toLocaleString()} stars</Caption>,
+        content: (
+          <A href={`${github.urls.repo}/stargazers`} style={styles.link}>
+            <Caption>{github.stats.stars.toLocaleString()} stars</Caption>
+          </A>
+        ),
       },
       github.stats.forks
         ? {
@@ -124,6 +139,17 @@ const generateData = (library, secondary, isDark) => {
             content: (
               <A href={`${github.urls.repo}/network/members`} style={styles.link}>
                 {`${github.stats.forks.toLocaleString()}`} forks
+              </A>
+            ),
+          }
+        : null,
+      github.stats.subscribers
+        ? {
+            id: 'subscribers',
+            icon: <Eye fill={iconColor} />,
+            content: (
+              <A href={`${github.urls.repo}/watchers`} style={styles.link}>
+                {`${github.stats.subscribers.toLocaleString()}`} watchers
               </A>
             ),
           }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

This PR adds the GitHub repository watchers count to the library metadata part.

We have the data for this a while, but it looks like I have forgot to expose it earlier. 😅 

Additionally, I have added the missing link to the GitHub repository stargazers.

### Preview

<img width="940" alt="Screenshot 2022-07-04 100043" src="https://user-images.githubusercontent.com/719641/177109665-8c69894d-492a-4a60-8b0d-011dfcc71b67.png">

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [X] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
