### PR TITLE
add new arch to Reanimated, add react-native-vector-drawable

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3116,7 +3116,8 @@
     "android": true,
     "tvos": true,
     "web": true,
-    "expo": true
+    "expo": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/osdnk/react-native-reanimated-bottom-sheet",
@@ -8579,5 +8580,15 @@
     "ios": true,
     "android": true,
     "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/klarna-incubator/react-native-vector-drawable",
+    "npmPkg": "@klarna/react-native-vector-drawable",
+    "examples": [
+      "https://github.com/klarna-incubator/react-native-vector-drawable/tree/master/example"
+    ],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

Since the support for the New Architecture status has landed we can add the new flag for the known packages which are migrated already (but detections fails to catch that). 

Reanimated [supports new arch](https://github.com/reactwg/react-native-new-architecture/discussions/14), so let's mark it. 

Additionally @oblador have mentioned one of the libraries which also support New Arch, but do not include the field which autodetection is looking for. Unfortunately this lib was not yet in the Directory, so let's add it now.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
