### PR TITLE
Rename some references from master to main

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -2,7 +2,7 @@ name: Deploy to production
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     # Run every 1 hour - https://crontab.guru/#0_*/1_*_*_*
     - cron: '0 */1 * * *'

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ GITHUB_TOKEN=<*> yarn data:update
 
 ## How do I deploy to production?
 
-Get a commit on `master` and it will be automatically deployed.
+Get a commit on `main` and it will be automatically deployed.
 
 ## I don't like your website, can I hit an API instead and build my own better stuff?
 


### PR DESCRIPTION
# 📝 Why & how

I found a reference to `master` in the `README.md`. Easy fix. Also noticed it was also referenced in the deployment yml - it seems like that should change, but happy to remove that one if we only want scheduled deploys.

💅💅💅
