### PR TITLE
Improve react-native-avoid-softinput examples & images

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6866,9 +6866,15 @@
     "android": true
   },
   {
-    "githubUrl": "https://github.com/mateusz1913/react-native-avoid-softinput",
+    "githubUrl": "https://github.com/mateusz1913/react-native-avoid-softinput/tree/master/packages/react-native-avoid-softinput",
     "examples": [
+      "https://github.com/mateusz1913/react-native-avoid-softinput/tree/master/packages/fabricMobile",
       "https://github.com/mateusz1913/react-native-avoid-softinput/tree/master/packages/mobile"
+    ],
+    "npmPkg": "react-native-avoid-softinput",
+    "images": [
+      "https://raw.githubusercontent.com/mateusz1913/react-native-avoid-softinput/master/static/form.gif",
+      "https://raw.githubusercontent.com/mateusz1913/react-native-avoid-softinput/master/static/sticky-footer.gif"
     ],
     "ios": true,
     "android": true
@@ -7606,7 +7612,9 @@
   {
     "githubUrl": "https://github.com/MobileReality/react-native-select-pro",
     "npmPkg": "@mobile-reality/react-native-select-pro",
-    "examples": ["https://github.com/MobileReality/react-native-select-pro/tree/master/apps/expo/src/examples"],
+    "examples": [
+      "https://github.com/MobileReality/react-native-select-pro/tree/master/apps/expo/src/examples"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -8724,18 +8732,14 @@
     "examples": [
       "https://github.com/Mindinventory/react-native-tabbar-interaction/tree/master/example"
     ],
-    "images": [
-      "https://cdn.dribbble.com/users/1233499/screenshots/4844696/preview.gif"
-    ],
+    "images": ["https://cdn.dribbble.com/users/1233499/screenshots/4844696/preview.gif"],
     "ios": true,
     "android": true
   },
   {
     "githubUrl": "https://github.com/Mindinventory/React-Native-top-navbar",
     "npmPkg": "@mindinventory/rn-top-navbar",
-    "examples": [
-      "https://github.com/Mindinventory/React-Native-top-navbar/tree/master/example"
-    ],
+    "examples": ["https://github.com/Mindinventory/React-Native-top-navbar/tree/master/example"],
     "ios": true,
     "android": true
   },
@@ -8748,9 +8752,7 @@
   {
     "githubUrl": "https://github.com/Mindinventory/react-native-stagger-view",
     "npmPkg": "@mindinventory/react-native-stagger-view",
-    "examples": [
-      "https://github.com/Mindinventory/react-native-stagger-view/tree/main/example"
-    ],
+    "examples": ["https://github.com/Mindinventory/react-native-stagger-view/tree/main/example"],
     "images": [
       "https://user-images.githubusercontent.com/88423352/160378928-a2e472c6-df2f-4e11-9566-cd1e32e67a3e.gif",
       "https://user-images.githubusercontent.com/88423352/160379456-33f6202c-4184-4ecd-852b-a85c099faf71.gif",
@@ -8773,9 +8775,7 @@
   {
     "githubUrl": "https://github.com/Mindinventory/react-native-speed-view",
     "npmPkg": "@mindinventory/react-native-speed-view",
-    "examples": [
-      "https://github.com/Mindinventory/react-native-speed-view/tree/main/example"
-    ],
+    "examples": ["https://github.com/Mindinventory/react-native-speed-view/tree/main/example"],
     "images": [
       "https://user-images.githubusercontent.com/82019401/164174514-2369be99-a00a-4171-a47d-95b997388bbe.gif"
     ],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
This PR adds missing examples and images for `react-native-avoid-softinput`, as well as it declares support for "New Architecture"

Note: `react-native-avoid-softinput` github repo is a monorepo and it turns out that the ["New Architecture" detection](https://github.com/react-native-community/directory/commit/4ae25e9fed97d8aae357a0cede3c7119d6d2a276) (btw awesome feature 🚀 ) does not support detecting inside monorepos. I also saw that 2 repos (reanimated and vector-drawable) [were added manually](https://github.com/react-native-community/directory/commit/f5cfbf23ccd498ade9efcbb15e912a04d57c6341) after detection feature landed. Technically this is undocumented, but for now, there's no other way to achieve it, so I just mirrored it for my library, let me know, if it's ok 😉 

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [X] Updated library in **`react-native-libraries.json`**

