### PR TITLE
add sort direction to directory API and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@
 - Add it at the end of `react-native-libraries.json` file.
 - Submit a PR.
 
-Please follow format, fields order and indentation as seen below, skip any of the `false` values and do not fill optional fields, unless it's necessary.
+> **Note** Please follow format, fields order and indentation as seen below, skip any of the `false` values and do not fill optional fields, unless it's necessary.
 
 ```json
 {
   "githubUrl": "<GITHUB REPOSITORY URL>",
   "npmPkg": "<OPTIONAL NPM PACKAGE NAME>",
-  "nameOverride": "<OPTIONALL PACKAGE DISPLAY NAME>",
+  "nameOverride": "<OPTIONAL PACKAGE DISPLAY NAME>",
   "examples": [
-    "<THE URL TO REPO>", 
+    "<THE URL TO REPO>",
     "<THE URL TO A SNACK>"
   ],
   "images": ["<PUBLIC URL TO RELATED IMAGE>"],
@@ -54,37 +54,37 @@ Please follow format, fields order and indentation as seen below, skip any of th
 
 - #### ❗ `githubUrl` **(required)**
   **(string)** - URL to the package GitHub repository (currently other Git hosts are not supported).
-  
-  > Package also needs to be published to the NPM registry, becouse it is a source of crucial data for the directory.
+
+  > Package also needs to be published to the NPM registry, because it is a source of crucial data for the directory.
 - #### `npmPkg`
   **(string)** - npm package name, by default GitHub repository name will be used. Example: `"@expo/react-native-action-sheet"`.
-  
+
   > Fill only when the GitHub repository name is different from the name of package published to npm, or the package is a part of monorepo.
 - #### `nameOverride`
   **(string)** - display name override.
-  
+
   > Fill only when it is different from the GitHub repository name and npm package name.
 - #### `examples`
   **(array of strings)** - URLs to example projects or Snacks which demonstrates the library.
 - #### `images`
   **(array of strings)** - URLs to static images or GIFs that shows the library functionality.
-  
-  > Please do not add logotypes or other branding metrials, and please avoid linking multiple resources which shows the same feature.
+
+  > Please do not add logotypes or other branding material, and please avoid linking multiple resources which shows the same feature.
 
 #### 📱 Platforms
 
-- #### `ios`
-  **(boolean)** - works on iOS device.
 - #### `android`
   **(boolean)** - works on Android device.
+- #### `ios`
+  **(boolean)** - works on iOS device.
 - #### `web`
   **(boolean)** - can be used with [`react-native-web`](https://github.com/necolas/react-native-web).
 - #### `expo`
   **(boolean)** - can be used in managed workflow, without ejecting an [Expo](https://github.com/expo/expo) application (any library can be used if you eject).
-  
+
 #### 🖥️ Out-of-tree Platforms
 
-> __Note:__ Adding out-of-tree platforms support requires an example or link to the app which uses the library on the given platform.
+> **Note** Adding out-of-tree platforms support requires an example or link to the app which uses the library on the given platform.
 
 - #### `windows`
   **(boolean)** - can be used with [`react-native-windows`](https://github.com/microsoft/react-native-windows).
@@ -104,7 +104,9 @@ Please follow format, fields order and indentation as seen below, skip any of th
 
 ---
 
-> __Note:__ If your package is within a monorepo on GitHub, eg: https://github.com/expo/expo/tree/main/packages/expo-web-browser, then the name, description, homepage, and topics (keywords) will be extracted from package.json for that subrepo. GitHub stats will be based on the monorepo, because there isn't really another option.
+> **Note** If your package is within a monorepo on GitHub, eg: https://github.com/expo/expo/tree/main/packages/expo-web-browser, 
+> then the name, description, homepage, and topics (keywords) will be extracted from `package.json` for that subrepo.
+> GitHub stats will be based on the monorepo, because there isn't really another option.
 
 ## How do I run my own version locally?
 

--- a/components/Icons/index.tsx
+++ b/components/Icons/index.tsx
@@ -210,11 +210,11 @@ export function Plus(props: Props) {
 export function Sort(props: Props) {
   const { width, height, fill = colors.black } = props;
   return (
-    <Svg width={width || 20} height={height || 12} viewBox="0 0 20 12" fill="none">
+    <Svg width={width || 16} height={height || 16} viewBox="0 0 16 16" fill="none">
       <Path
         fillRule="evenodd"
         clipRule="evenodd"
-        d="M12.954 2.978H.38V.758h12.574v2.22zM11.239 7.421L.379 7.416l.002-2.219 10.859.005-.001 2.22zM9.52 11.854H.38V9.635h9.14v2.22zM12.954 6.963h2.797V1.45a.692.692 0 011.384 0v5.512h2.766l-3.455 4.871-3.492-4.871z"
+        d="M10.3,5H0V3h10.3V5z M8.9,9L0,9l0-2l8.9,0L8.9,9L8.9,9z M7.5,13H0v-2h7.5V13L7.5,13z M10.3,8.6h2.3v-5c0-0.3,0.3-0.6,0.6-0.6c0.3,0,0.6,0.3,0.6,0.6v5H16L13.2,13L10.3,8.6L10.3,8.6z"
         fill={fill}
       />
     </Svg>

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,4 +1,5 @@
 export type QueryOrder =
+  | 'relevance'
   | 'updated'
   | 'added'
   | 'recommended'
@@ -7,6 +8,8 @@ export type QueryOrder =
   | 'issues'
   | 'downloads'
   | 'stars';
+
+export type QueryOrderDirection = 'descending' | 'ascending';
 
 export type Query = {
   android?: string;
@@ -17,6 +20,7 @@ export type Query = {
   web?: string;
   windows?: string;
   order?: QueryOrder;
+  direction?: QueryOrderDirection;
   search?: string;
   offset?: string | number;
   limit?: string | number;
@@ -32,7 +36,7 @@ export type Query = {
 };
 
 export type Library = {
-  goldstar: boolean;
+  goldstar?: boolean;
   githubUrl: string;
   ios?: boolean;
   android?: boolean;
@@ -57,10 +61,9 @@ export type Library = {
       hasPages: boolean;
       hasDownloads: boolean;
       hasTopics: boolean;
-      updatedAt: Date;
-      createdAt: Date;
-      pushedAt: Date;
-      forks: number;
+      updatedAt: Date | string;
+      createdAt: Date | string;
+      pushedAt: Date | string;
       issues: number;
       subscribers: number;
       stars: number;
@@ -68,7 +71,7 @@ export type Library = {
     name: string;
     fullName: string;
     description: string;
-    topics: [];
+    topics: string[];
     license: {
       key: string;
       name: string;
@@ -79,8 +82,8 @@ export type Library = {
     lastRelease: {
       name: string;
       tagName: string;
-      createdAt: Date;
-      publishedAt: Date;
+      createdAt: Date | string;
+      publishedAt: Date | string;
       isPrerelease: boolean;
     };
     hasTypes: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

Currently we always use the descending order when presenting results. Let's add an ability to change the order via API query param ans support that feature on the directory website.

I have also added a logic to skip default sort related values from the query on the website and fixed the sorting-related types.

Additionally, I have fixed few typos and made formatting changes in project Readme.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.

# 📷 Preview

![demo](https://user-images.githubusercontent.com/719641/206876309-1eec3732-33e3-4bc2-98ff-470c4db3ae11.gif)
