### PR TITLE
Remove Expo Go on MMKV library since not supported

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6316,8 +6316,7 @@
     "examples": ["https://github.com/mrousavy/react-native-mmkv/tree/master/example"],
     "ios": true,
     "android": true,
-    "web": true,
-    "expo": true
+    "web": true
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-vision-camera",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

I removed the Expo Go support on the MMKV library because Expo Go is not supported, see:  https://github.com/mrousavy/react-native-mmkv/issues/549


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
