### PR TITLE
UX tweak for filters and fix for new arch one

### DIFF
--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -72,9 +72,9 @@ const ToggleLink = ({ query, paramName, title, basePath = '/' }) => {
   );
 };
 
-export const FilterButton = (props: FilterButtonProps) => {
+export const FilterButton = ({ isFilterVisible, query, onPress }: FilterButtonProps) => {
   const { isDark } = useContext(CustomAppearanceContext);
-  const { isFilterVisible, query, onPress } = props;
+
   const params = [
     ...platforms.map(platform => platform.param),
     'hasExample',
@@ -84,7 +84,9 @@ export const FilterButton = (props: FilterButtonProps) => {
     'isPopular',
     'isRecommended',
     'wasRecentlyUpdated',
+    'newArchitecture',
   ];
+
   const filterCount = Object.keys(query).reduce(
     (acc, q) => (params.includes(q) ? acc + 1 : acc),
     0
@@ -100,7 +102,11 @@ export const FilterButton = (props: FilterButtonProps) => {
       ]}>
       <View style={styles.displayHorizontal}>
         <View style={styles.iconContainer}>
-          <FilterIcon fill={isFilterVisible ? colors.gray7 : colors.white} width={14} height={12} />
+          <FilterIcon
+            fill={isFilterVisible ? colors.gray7 : filterCount > 0 ? colors.primary : colors.white}
+            width={14}
+            height={12}
+          />
         </View>
         <P style={[styles.buttonText, isFilterVisible && styles.activeButtonText]}>
           Filters{filterCount > 0 ? `: ${filterCount}` : ''}

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 const Search = ({ query, total }: Props) => {
   const [isInputFocused, setInputFocused] = useState(false);
-  const [isFilterVisible, setFilterVisible] = useState(false);
+  const [isFilterVisible, setFilterVisible] = useState(Object.keys(query).length > 0);
   const [isApple, setIsApple] = useState<boolean | null>(null);
   const inputRef = useRef(null);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

https://twitter.com/gabimoncha/status/1737064349422829868

As reported, the UX when landing on directory page with params already included do not correctly open the filters pane. Also, the "New Architecture" filter has been missed in active filters counter, which also added to the confusion.

Additionally, to strengthen the indication that filters are selected, even with pane close I have modified the component icon color.

# Preview

![Screenshot 2023-12-19 at 15 16 16](https://github.com/react-native-community/directory/assets/719641/a38aa563-8cdd-423b-acf7-5c8b4a82f108)

![Screenshot 2023-12-19 at 15 15 32](https://github.com/react-native-community/directory/assets/719641/da286b34-01df-4492-8b30-95760d797218)

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
