### PR TITLE
Add unmaintained to react-native-billing

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4226,7 +4226,8 @@
   },
   {
     "githubUrl": "https://github.com/idehub/react-native-billing",
-    "android": true
+    "android": true,
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/TaylorBriggs/react-native-typewriter",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

Recently, was going through the directory to find what libraries are available for in app purchases in our ecosystem. Found that [`react-native-billing`](https://github.com/idehub/react-native-billing) is no longer maintained.

Updated `react-native-libraries.json` to reflect the same.
