### PR TITLE
mark as unmaintained EkoLabs/react-native-background-downloader

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5350,7 +5350,8 @@
   {
     "githubUrl": "https://github.com/EkoLabs/react-native-background-downloader",
     "ios": true,
-    "android": true
+    "android": true,
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/mrousavy/react-native-google-nearby-messages",


### PR DESCRIPTION
Hi

- [x] Updated library in **`react-native-libraries.json`**

This repo is unmaintained for 2 years already

https://github.com/EkoLabs/react-native-background-downloader