### PR TITLE
Updated react-native-svg and lottie-react-native for windows support and added react-native-windows-hello

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -522,6 +522,7 @@
     ],
     "ios": true,
     "android": true,
+    "windows": true,
     "expoGo": true,
     "examples": ["https://snack.expo.dev/SJdIbHe4b"],
     "goldstar": true
@@ -3763,7 +3764,8 @@
     "android": true,
     "expoGo": true,
     "tvos": true,
-    "web": true
+    "web": true,
+    "windows": true
   },
   {
     "githubUrl": "https://github.com/dooboolab/react-native-iap",
@@ -10752,5 +10754,10 @@
     "examples": ["https://github.com/bluesky-social/react-native-uitextview/tree/main/example"],
     "images": ["https://haileyok.com/content/images/size/w1920/2024/01/IMG_4730.jpeg"],
     "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/callstack/react-native-windows-hello",
+    "npmPkg": "react-native-windows-hello",
+    "windows": true
   }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
Currently, react-native-windows has support for react-native-svg and lottie-react-native, which this change will update the directory to reflect. Additionally, this PR also adds the [react-native-windows-hello](https://github.com/callstack/react-native-windows-hello) module to the directory with windows support.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [X] Added library to **`react-native-libraries.json`**
- [X] Updated library in **`react-native-libraries.json`**