### PR TITLE
chore: List visionOS support to several libraries

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3224,6 +3224,7 @@
     "android": true,
     "windows": true,
     "macos": true,
+    "visionos": true,
     "npmPkg": "@react-native-clipboard/clipboard"
   },
   {
@@ -3265,7 +3266,8 @@
     "android": true,
     "expoGo": true,
     "windows": true,
-    "macos": true
+    "macos": true,
+    "visionos": true
   },
   {
     "githubUrl": "https://github.com/react-native-camera/react-native-camera",
@@ -3323,7 +3325,8 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "windows": true
+    "windows": true,
+    "visionos": true
   },
   {
     "githubUrl": "https://github.com/microsoft/react-native-dualscreen/tree/master/dualscreeninfo",
@@ -3765,7 +3768,9 @@
     "expoGo": true,
     "tvos": true,
     "web": true,
-    "windows": true
+    "windows": true,
+    "macos": true,
+    "visionos": true
   },
   {
     "githubUrl": "https://github.com/dooboolab/react-native-iap",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

A couple of libraries have visionOS support in their latest version. Let's list that. I also updated one that was missing listing macOS support. 


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
