### PR TITLE
add an ability to display note about new architecture support

### DIFF
--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -19,62 +19,155 @@ import {
   TypeScript,
   ReactLogo,
 } from '../Icons';
+import Tooltip from '../Tooltip';
 
 type Props = {
   library: LibraryType;
   secondary?: boolean;
 };
 
-const generateData = (library: LibraryType, secondary: boolean, isDark: boolean) => {
-  const { github, newArchitecture, examples, score, npm, npmPkg } = library;
+function generateData(library: LibraryType, isDark: boolean) {
+  const { github, score, npm, npmPkg } = library;
 
-  if (secondary) {
-    const secondaryTextColor = {
-      color: isDark ? darkColors.secondary : colors.gray5,
-    };
-    const iconColor = isDark ? darkColors.pewter : colors.secondary;
-    const paragraphStyles = [styles.secondaryText, secondaryTextColor];
-    const linkStyles = [...paragraphStyles, styles.mutedLink];
-    const hoverStyle = isDark && { color: colors.primaryDark };
+  const iconColor = isDark ? darkColors.pewter : colors.gray5;
+  return [
+    {
+      id: 'score',
+      icon: <DirectoryScore score={score} />,
+      content: (
+        <A
+          target="_self"
+          href="/scoring"
+          style={{ ...styles.link, ...styles.mutedLink }}
+          hoverStyle={isDark && { color: colors.primaryDark }}>
+          Directory Score
+        </A>
+      ),
+    },
+    {
+      id: 'calendar',
+      icon: <Calendar fill={iconColor} />,
+      content: <Caption>Updated {getTimeSinceToday(github.stats.pushedAt)}</Caption>,
+    },
+    npm.downloads
+      ? {
+          id: 'downloads',
+          icon: <Download fill={iconColor} width={16} height={18} />,
+          content: (
+            <A href={`https://www.npmjs.com/package/${npmPkg}`} style={styles.link}>
+              {`${npm.downloads.toLocaleString()}`} {npm.period}ly downloads
+            </A>
+          ),
+        }
+      : null,
+    {
+      id: 'star',
+      icon: <Star fill={iconColor} />,
+      content: (
+        <A href={`${github.urls.repo}/stargazers`} style={styles.link}>
+          {github.stats.stars.toLocaleString()} stars
+        </A>
+      ),
+    },
+    github.stats.forks
+      ? {
+          id: 'forks',
+          icon: <Fork fill={iconColor} width={16} height={17} />,
+          content: (
+            <A href={`${github.urls.repo}/network/members`} style={styles.link}>
+              {`${github.stats.forks.toLocaleString()}`} forks
+            </A>
+          ),
+        }
+      : null,
+    github.stats.subscribers
+      ? {
+          id: 'subscribers',
+          icon: <Eye fill={iconColor} />,
+          content: (
+            <A href={`${github.urls.repo}/watchers`} style={styles.link}>
+              {`${github.stats.subscribers.toLocaleString()}`} watchers
+            </A>
+          ),
+        }
+      : null,
+    github.stats.issues
+      ? {
+          id: 'issues',
+          icon: <Issue fill={iconColor} />,
+          content: (
+            <A href={`${github.urls.repo}/issues`} style={styles.link}>
+              {`${github.stats.issues.toLocaleString()}`} issues
+            </A>
+          ),
+        }
+      : null,
+  ];
+}
 
-    return [
-      github.urls.homepage
-        ? {
-            id: 'web',
-            icon: <Web fill={iconColor} width={16} height={16} />,
-            content: (
-              <A href={github.urls.homepage} style={linkStyles} hoverStyle={hoverStyle}>
-                Website
+function generateSecondaryData(library: LibraryType, isDark: boolean) {
+  const { github, newArchitecture, examples } = library;
+  const secondaryTextColor = {
+    color: isDark ? darkColors.secondary : colors.gray5,
+  };
+  const iconColor = isDark ? darkColors.pewter : colors.secondary;
+  const paragraphStyles = [styles.secondaryText, secondaryTextColor];
+  const linkStyles = [...paragraphStyles, styles.mutedLink];
+  const hoverStyle = isDark && { color: colors.primaryDark };
+
+  return [
+    github.urls.homepage
+      ? {
+          id: 'web',
+          icon: <Web fill={iconColor} width={16} height={16} />,
+          content: (
+            <A href={github.urls.homepage} style={linkStyles} hoverStyle={hoverStyle}>
+              Website
+            </A>
+          ),
+        }
+      : null,
+    github.license
+      ? {
+          id: 'license',
+          icon: <License fill={iconColor} width={14} height={16} />,
+          content:
+            github.license.name === 'Other' ? (
+              <P style={paragraphStyles}>Unrecognized License</P>
+            ) : (
+              <A href={github.license.url} style={linkStyles} hoverStyle={hoverStyle}>
+                {github.license.name}
               </A>
             ),
-          }
-        : null,
-      github.license
-        ? {
-            id: 'license',
-            icon: <License fill={iconColor} width={14} height={16} />,
-            content:
-              github.license.name === 'Other' ? (
-                <P style={paragraphStyles}>Unrecognized License</P>
-              ) : (
-                <A href={github.license.url} style={linkStyles} hoverStyle={hoverStyle}>
-                  {github.license.name}
-                </A>
-              ),
-          }
-        : null,
-      github.hasTypes
-        ? {
-            id: 'types',
-            icon: <TypeScript fill={iconColor} width={16} height={16} />,
-            content: <P style={paragraphStyles}>TypeScript Types</P>,
-          }
-        : null,
-      newArchitecture || github.newArchitecture
-        ? {
-            id: 'newArchitecture',
-            icon: <ReactLogo fill={iconColor} width={17} height={17} />,
-            content: (
+        }
+      : null,
+    github.hasTypes
+      ? {
+          id: 'types',
+          icon: <TypeScript fill={iconColor} width={16} height={16} />,
+          content: <P style={paragraphStyles}>TypeScript Types</P>,
+        }
+      : null,
+    newArchitecture || github.newArchitecture
+      ? {
+          id: 'newArchitecture',
+          icon: <ReactLogo fill={iconColor} width={17} height={17} />,
+          content:
+            typeof newArchitecture === 'string' ? (
+              <Tooltip
+                trigger={
+                  <View>
+                    <A
+                      href="https://reactnative.dev/docs/new-architecture-intro"
+                      style={linkStyles}
+                      hoverStyle={hoverStyle}>
+                      New Architecture
+                    </A>
+                  </View>
+                }>
+                {newArchitecture}
+              </Tooltip>
+            ) : (
               <A
                 href="https://reactnative.dev/docs/new-architecture-intro"
                 style={linkStyles}
@@ -82,110 +175,34 @@ const generateData = (library: LibraryType, secondary: boolean, isDark: boolean)
                 New Architecture
               </A>
             ),
-          }
-        : null,
-      examples && examples.length
-        ? {
-            id: 'examples',
-            icon: <Code fill={iconColor} width={16} height={16} />,
-            content: (
-              <>
-                <Caption style={paragraphStyles}>Examples: </Caption>
-                {examples.map((example, index) => (
-                  <A
-                    key={example}
-                    href={example}
-                    style={[...linkStyles, styles.exampleLink]}
-                    hoverStyle={hoverStyle}>
-                    #{index + 1}
-                  </A>
-                ))}
-              </>
-            ),
-          }
-        : null,
-    ];
-  } else {
-    const iconColor = isDark ? darkColors.pewter : colors.gray5;
-    return [
-      {
-        id: 'score',
-        icon: <DirectoryScore score={score} />,
-        content: (
-          <A
-            target="_self"
-            href="/scoring"
-            style={{ ...styles.link, ...styles.mutedLink }}
-            hoverStyle={isDark && { color: colors.primaryDark }}>
-            Directory Score
-          </A>
-        ),
-      },
-      {
-        id: 'calendar',
-        icon: <Calendar fill={iconColor} />,
-        content: <Caption>Updated {getTimeSinceToday(github.stats.pushedAt)}</Caption>,
-      },
-      npm.downloads
-        ? {
-            id: 'downloads',
-            icon: <Download fill={iconColor} width={16} height={18} />,
-            content: (
-              <A href={`https://www.npmjs.com/package/${npmPkg}`} style={styles.link}>
-                {`${npm.downloads.toLocaleString()}`} {npm.period}ly downloads
-              </A>
-            ),
-          }
-        : null,
-      {
-        id: 'star',
-        icon: <Star fill={iconColor} />,
-        content: (
-          <A href={`${github.urls.repo}/stargazers`} style={styles.link}>
-            {github.stats.stars.toLocaleString()} stars
-          </A>
-        ),
-      },
-      github.stats.forks
-        ? {
-            id: 'forks',
-            icon: <Fork fill={iconColor} width={16} height={17} />,
-            content: (
-              <A href={`${github.urls.repo}/network/members`} style={styles.link}>
-                {`${github.stats.forks.toLocaleString()}`} forks
-              </A>
-            ),
-          }
-        : null,
-      github.stats.subscribers
-        ? {
-            id: 'subscribers',
-            icon: <Eye fill={iconColor} />,
-            content: (
-              <A href={`${github.urls.repo}/watchers`} style={styles.link}>
-                {`${github.stats.subscribers.toLocaleString()}`} watchers
-              </A>
-            ),
-          }
-        : null,
-      github.stats.issues
-        ? {
-            id: 'issues',
-            icon: <Issue fill={iconColor} />,
-            content: (
-              <A href={`${github.urls.repo}/issues`} style={styles.link}>
-                {`${github.stats.issues.toLocaleString()}`} issues
-              </A>
-            ),
-          }
-        : null,
-    ];
-  }
-};
+        }
+      : null,
+    examples && examples.length
+      ? {
+          id: 'examples',
+          icon: <Code fill={iconColor} width={16} height={16} />,
+          content: (
+            <>
+              <Caption style={paragraphStyles}>Examples: </Caption>
+              {examples.map((example, index) => (
+                <A
+                  key={example}
+                  href={example}
+                  style={[...linkStyles, styles.exampleLink]}
+                  hoverStyle={hoverStyle}>
+                  #{index + 1}
+                </A>
+              ))}
+            </>
+          ),
+        }
+      : null,
+  ];
+}
 
 export function MetaData({ library, secondary }: Props) {
   const { isDark } = useContext(CustomAppearanceContext);
-  const data = generateData(library, secondary, isDark);
+  const data = secondary ? generateSecondaryData(library, isDark) : generateData(library, isDark);
 
   return (
     <>

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -23,7 +23,14 @@ const Library = ({ library, skipMeta, showPopularity }: Props) => {
   const { isDark } = useContext(CustomAppearanceContext);
   const { github } = library;
   const { isSmallScreen, isBelowMaxWidth } = useLayout();
-  const libName = library.nameOverride || library.npmPkg || github.name;
+
+  const libName = library.nameOverride ?? library.npmPkg ?? github.name;
+  const hasSecondaryMetadata =
+    github.license ||
+    github.urls.homepage ||
+    github.newArchitecture ||
+    library.newArchitecture ||
+    (library.examples && library.examples.length);
 
   return (
     <View
@@ -70,7 +77,7 @@ const Library = ({ library, skipMeta, showPopularity }: Props) => {
             ))}
           </View>
         ) : null}
-        {github.license || github.urls.homepage || (library.examples && library.examples.length) ? (
+        {hasSecondaryMetadata ? (
           <>
             {isSmallScreen ? null : <View style={styles.filler} />}
             <View style={[styles.bottomBar, isSmallScreen ? styles.bottomBarSmall : {}]}>

--- a/react-native-libraries.schema.json
+++ b/react-native-libraries.schema.json
@@ -119,11 +119,11 @@
         "examples": [true]
       },
       "newArchitecture": {
-        "$id": "#/items/properties/newArch",
-        "type": "boolean",
+        "$id": "#/items/properties/newArchitecture",
+        "type": ["boolean", "string"],
         "title": "The New Architecture Support Schema",
         "default": false,
-        "examples": [true]
+        "examples": [true, "Only iOS supported"]
       }
     }
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,9 +10,9 @@ html, body {
 
 .TooltipContent {
   border-radius: 4px;
-  padding: 10px 15px;
+  padding: 8px 14px;
   font-size: 13px;
-  line-height: 1;
+  line-height: 1.5;
   color: #fff;
   background-color: #000;
   box-shadow: hsl(206 22% 7% / 40%) 0 10px 38px -10px, hsl(206 22% 7% / 25%) 0 10px 20px -15px;
@@ -20,6 +20,7 @@ html, body {
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;
+  max-width: 220px;
 }
 
 .TooltipContent[data-state='delayed-open'][data-side='top'] {

--- a/types/index.ts
+++ b/types/index.ts
@@ -50,7 +50,7 @@ export type Library = {
   unmaintained?: boolean | string;
   dev?: boolean;
   template?: boolean;
-  newArchitecture?: boolean;
+  newArchitecture?: boolean | string;
   github: {
     urls: {
       repo: string;


### PR DESCRIPTION
# 📝 Why & how

Sometimes it might be useful to add a note to the new architecture support meta block to indicate partial support or temporary limitations.

This PR enables passing string to the `newArchitecture` field at library root level, which then will be display in the tooltip above the new architecture link on hover, if present.

Additionally, I have split the metadata block generating method for a bit better readability.

# Preview

https://react-native-directory-1e4wc1baz-rndir.vercel.app/

![Screenshot 2024-06-26 204431](https://github.com/react-native-community/directory/assets/719641/7729f42c-5dc8-425c-92c0-7fe07829481c)

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [x] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
