### PR TITLE
fix(libraries): rn-voice/voice does not support Expo Go

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3228,7 +3228,6 @@
     "githubUrl": "https://github.com/react-native-voice/voice",
     "ios": true,
     "android": true,
-    "expoGo": false,
     "npmPkg": "@react-native-voice/voice"
   },
   {

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3228,7 +3228,7 @@
     "githubUrl": "https://github.com/react-native-voice/voice",
     "ios": true,
     "android": true,
-    "expoGo": true,
+    "expoGo": false,
     "npmPkg": "@react-native-voice/voice"
   },
   {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
- Addresses a bug in the listing for `@react-native-voice/voice`, where it shows it supports Expo Go. As per the [README documentation](https://github.com/react-native-voice/voice?tab=readme-ov-file#prebuild-plugin), it does not.
- Simply changes the `expoGo` boolean to false


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
