### PR TITLE
Make the unmaintained threshold 2 years

### DIFF
--- a/scripts/build-and-score-data.js
+++ b/scripts/build-and-score-data.js
@@ -57,7 +57,7 @@ const buildAndScoreData = async () => {
     if (!project.unmaintained) {
       if (project.github.isArchived) {
         project.unmaintained = true;
-      } else if (isLaterThan(project.github.stats.pushedAt, TimeRange.YEAR * 4)) {
+      } else if (isLaterThan(project.github.stats.pushedAt, TimeRange.YEAR * 2)) {
         project.unmaintained = true;
       }
     }


### PR DESCRIPTION
# 📝 Why & how

We want to ensure that folks know if they are going to be installing an unmaintained library. I think it is fair to assume in a fast moving ecosystem like React Native, if a library has not been touched in 2 years on GitHub then it is probably not maintained. We can mark exceptions by setting `unmantained` explicitly to `false`. Also, we can follow up here more later if we add detection for JS-only/native library types.
