### PR TITLE
Add hidden filter for unmaintained libs

### DIFF
--- a/util/search.js
+++ b/util/search.js
@@ -117,7 +117,11 @@ export const handleFilterLibraries = ({
       return false;
     }
 
-    if (isMaintained && library.unmaintained) {
+    if (isMaintained === 'false' && !library.unmaintained) {
+      return false;
+    }
+
+    if (isMaintained === 'true' && library.unmaintained) {
       return false;
     }
 


### PR DESCRIPTION
# 📝 Why & how

It can occasionally be useful to look through a list of *only unmaintained libraries*. This makes it possible by adding the `isMaintained=false` query param
