### PR TITLE
convert New Architecture metadata to compatibility tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@
   **(boolean)** - signify that a library is a new project template.
 - #### `newArchitecture`
 
-  **(boolean)** - signify that a library supports the new architecture
+  **(boolean)** - signify that a library supports, or not, the new architecture. Skipping the field will result in "untested" status, unless automatic support detection returned a result. 
 
   > Set this tag only when automatic architecture detection fails for your package, despite it supports the new architecture.
 

--- a/components/CompatibilityTags.tsx
+++ b/components/CompatibilityTags.tsx
@@ -1,36 +1,14 @@
 import { useContext } from 'react';
-import { View, StyleSheet, ViewStyle } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
-import { Check } from './Icons';
-import { colors, darkColors, Label } from '../common/styleguide';
+import { NewArchitectureTag } from './Library/NewArchitectureTag';
+import { Tag } from './Tag';
+import { colors, darkColors } from '../common/styleguide';
 import CustomAppearanceContext from '../context/CustomAppearanceContext';
 import { Library } from '../types';
 
 type Props = {
   library: Library;
-};
-
-type TagProps = {
-  label: string;
-  tagStyle: ViewStyle;
-  showCheck?: boolean;
-};
-
-const Tag = ({ label, tagStyle, showCheck = true }: TagProps) => {
-  const { isDark } = useContext(CustomAppearanceContext);
-  return (
-    <View key={label} style={[styles.tag, tagStyle]}>
-      {showCheck ? <Check width={12} height={8} fill={colors.gray5} /> : null}
-      <Label
-        style={[
-          {
-            color: isDark ? darkColors.secondary : colors.black,
-          },
-        ]}>
-        {label}
-      </Label>
-    </View>
-  );
 };
 
 export function CompatibilityTags({ library }: Props) {
@@ -57,7 +35,7 @@ export function CompatibilityTags({ library }: Props) {
             backgroundColor: isDark ? '#2b1c48' : '#e3d8f8',
             borderColor: isDark ? '#482f72' : '#d3c2f2',
           }}
-          showCheck={false}
+          icon={null}
         />
       ) : null}
       {library.template ? (
@@ -67,9 +45,10 @@ export function CompatibilityTags({ library }: Props) {
             backgroundColor: isDark ? '#173137' : '#d8f8f1',
             borderColor: isDark ? '#28555a' : '#b2ddce',
           }}
-          showCheck={false}
+          icon={null}
         />
       ) : null}
+      <NewArchitectureTag library={library} />
       {platforms.map(platform => (
         <Tag
           label={platform}
@@ -91,16 +70,5 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     marginBottom: -4,
     gap: 6,
-  },
-  tag: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderWidth: 1,
-    borderRadius: 4,
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    marginBottom: 4,
-    userSelect: 'none',
-    gap: 4,
   },
 });

--- a/components/CompatibilityTags.tsx
+++ b/components/CompatibilityTags.tsx
@@ -32,8 +32,8 @@ export function CompatibilityTags({ library }: Props) {
         <Tag
           label="Development Tool"
           tagStyle={{
-            backgroundColor: isDark ? '#2b1c48' : '#e3d8f8',
-            borderColor: isDark ? '#482f72' : '#d3c2f2',
+            backgroundColor: isDark ? '#261a3d' : '#ece3fc',
+            borderColor: isDark ? '#3d2861' : '#d9c8fa',
           }}
           icon={null}
         />
@@ -42,13 +42,13 @@ export function CompatibilityTags({ library }: Props) {
         <Tag
           label="Template"
           tagStyle={{
-            backgroundColor: isDark ? '#173137' : '#d8f8f1',
-            borderColor: isDark ? '#28555a' : '#b2ddce',
+            backgroundColor: isDark ? '#37172e' : '#fce1f5',
+            borderColor: isDark ? '#52213e' : '#f5c6e8',
           }}
           icon={null}
         />
       ) : null}
-      <NewArchitectureTag library={library} />
+      {!library.dev && !library.template && <NewArchitectureTag library={library} />}
       {platforms.map(platform => (
         <Tag
           label={platform}

--- a/components/Icons/index.tsx
+++ b/components/Icons/index.tsx
@@ -204,6 +204,31 @@ export function Plus({ width, height, fill = colors.black }: Props) {
   );
 }
 
+export function XIcon({ width, height, fill = colors.black }: Props) {
+  return (
+    <Svg
+      width={width || 16}
+      height={height || 16}
+      viewBox="0 0 16 16"
+      fill="none"
+      style={{ transform: 'rotate(45deg)' }}>
+      <Path fillRule="evenodd" clipRule="evenodd" d="M.114 7.12H15.57v2H.114v-2z" fill={fill} />
+      <Path fillRule="evenodd" clipRule="evenodd" d="M6.842 15.848V.393h2v15.455h-2z" fill={fill} />
+    </Svg>
+  );
+}
+
+export function Question({ width, height, fill = colors.black }: Props) {
+  return (
+    <Svg width={width || 16} height={height || 16} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M9.88849 16.0515H13.0629V15.8036C13.082 13.7826 13.7398 12.858 15.2936 11.9047C17.0477 10.8561 18.144 9.42612 18.144 7.24309C18.144 4.02097 15.6368 2 11.9953 2C8.65875 2 5.95141 3.84938 5.85608 7.47188H9.24979C9.33558 5.67969 10.6321 4.82173 11.9762 4.82173C13.4347 4.82173 14.6073 5.79409 14.6073 7.29075C14.6073 8.62536 13.7207 9.54051 12.5672 10.265C10.8799 11.3136 9.90756 12.3718 9.88849 15.8036V16.0515ZM11.5567 22C12.6816 22 13.6444 21.0658 13.654 19.9028C13.6444 18.7588 12.6816 17.8246 11.5567 17.8246C10.3937 17.8246 9.44998 18.7588 9.45951 19.9028C9.44998 21.0658 10.3937 22 11.5567 22Z"
+        fill={fill}
+      />
+    </Svg>
+  );
+}
+
 export function Sort({ width, height, fill = colors.black }: Props) {
   return (
     <Svg width={width || 16} height={height || 16} viewBox="0 0 16 16" fill="none">

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -24,9 +24,7 @@ type Props = {
   secondary?: boolean;
 };
 
-function generateData(library: LibraryType, isDark: boolean) {
-  const { github, score, npm, npmPkg } = library;
-
+function generateData({ github, score, npm, npmPkg }: LibraryType, isDark: boolean) {
   const iconColor = isDark ? darkColors.pewter : colors.gray5;
   return [
     {
@@ -107,8 +105,7 @@ function generateData(library: LibraryType, isDark: boolean) {
   ];
 }
 
-function generateSecondaryData(library: LibraryType, isDark: boolean) {
-  const { github, newArchitecture, examples } = library;
+function generateSecondaryData({ github, examples }: LibraryType, isDark: boolean) {
   const secondaryTextColor = {
     color: isDark ? darkColors.secondary : colors.gray5,
   };

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -17,9 +17,7 @@ import {
   Fork,
   Code,
   TypeScript,
-  ReactLogo,
 } from '../Icons';
-import Tooltip from '../Tooltip';
 
 type Props = {
   library: LibraryType;
@@ -150,35 +148,6 @@ function generateSecondaryData(library: LibraryType, isDark: boolean) {
           id: 'types',
           icon: <TypeScript fill={iconColor} width={16} height={16} />,
           content: <P style={paragraphStyles}>TypeScript Types</P>,
-        }
-      : null,
-    newArchitecture || github.newArchitecture
-      ? {
-          id: 'newArchitecture',
-          icon: <ReactLogo fill={iconColor} width={17} height={17} />,
-          content:
-            typeof newArchitecture === 'string' ? (
-              <Tooltip
-                trigger={
-                  <View>
-                    <A
-                      href="https://reactnative.dev/docs/new-architecture-intro"
-                      style={linkStyles}
-                      hoverStyle={hoverStyle}>
-                      New Architecture
-                    </A>
-                  </View>
-                }>
-                {newArchitecture}
-              </Tooltip>
-            ) : (
-              <A
-                href="https://reactnative.dev/docs/new-architecture-intro"
-                style={linkStyles}
-                hoverStyle={hoverStyle}>
-                New Architecture
-              </A>
-            ),
         }
       : null,
     examples && examples.length

--- a/components/Library/NewArchitectureTag.tsx
+++ b/components/Library/NewArchitectureTag.tsx
@@ -40,7 +40,9 @@ export function NewArchitectureTag({ library }: Props) {
         side="bottom"
         trigger={
           <View>
-            <HtmlElements.A href="https://reactnative.dev/docs/new-architecture-intro">
+            <HtmlElements.A
+              href="https://reactnative.dev/docs/new-architecture-intro"
+              target="_blank">
               <Tag label="New Architecture" icon={icon} tagStyle={getTagColor(status, isDark)} />
             </HtmlElements.A>
           </View>
@@ -87,7 +89,7 @@ function getIconColor(status: SupportStatus, isDark: boolean) {
     case SupportStatus.Unsupported:
       return isDark ? darkColors.warning : colors.warningDark;
     default:
-      return colors.gray5;
+      return colors.gray4;
   }
 }
 
@@ -95,18 +97,18 @@ function getTagColor(status: SupportStatus, isDark: boolean) {
   switch (status) {
     case SupportStatus.Supported:
       return {
-        backgroundColor: isDark ? '#142933' : '#e8f6fc',
-        borderColor: isDark ? '#1e4047' : '#cdedf7',
+        backgroundColor: isDark ? '#142733' : '#edf6fc',
+        borderColor: isDark ? '#203b4d' : '#d4ebfa',
       };
     case SupportStatus.Unsupported:
       return {
-        backgroundColor: isDark ? darkColors.warningLight : '#fffae0',
-        borderColor: isDark ? '#3d3306' : '#fcee9d',
+        backgroundColor: isDark ? '#292005' : '#fffae8',
+        borderColor: isDark ? '#3d3206' : '#faebaf',
       };
     default:
       return {
-        backgroundColor: isDark ? darkColors.dark : colors.gray1,
         borderColor: isDark ? darkColors.border : colors.gray2,
+        borderStyle: 'dashed' as 'dashed',
       };
   }
 }

--- a/components/Library/NewArchitectureTag.tsx
+++ b/components/Library/NewArchitectureTag.tsx
@@ -1,0 +1,120 @@
+import * as HtmlElements from '@expo/html-elements';
+import { useContext } from 'react';
+import { View, StyleSheet } from 'react-native';
+
+import { colors, darkColors, Label } from '../../common/styleguide';
+import CustomAppearanceContext from '../../context/CustomAppearanceContext';
+import { Library } from '../../types';
+import { Check, Question, XIcon } from '../Icons';
+import { Tag } from '../Tag';
+import Tooltip from '../Tooltip';
+
+type Props = {
+  library: Library;
+};
+
+enum SupportStatus {
+  Supported = 'supported',
+  Unsupported = 'unsupported',
+  Untested = 'untested',
+}
+
+export function NewArchitectureTag({ library }: Props) {
+  const { isDark } = useContext(CustomAppearanceContext);
+
+  const hasNote = typeof library.newArchitecture === 'string';
+  const status = getSupportStatus(library, hasNote);
+
+  const icon =
+    status === SupportStatus.Unsupported ? (
+      <XIcon fill={getIconColor(status, isDark)} width={11} height={11} />
+    ) : status === SupportStatus.Supported ? (
+      <Check fill={getIconColor(status, isDark)} width={12} height={12} />
+    ) : (
+      <Question fill={getIconColor(status, isDark)} width={11} height={11} />
+    );
+
+  return (
+    <View>
+      <Tooltip
+        side="bottom"
+        trigger={
+          <View>
+            <HtmlElements.A href="https://reactnative.dev/docs/new-architecture-intro">
+              <Tag label="New Architecture" icon={icon} tagStyle={getTagColor(status, isDark)} />
+            </HtmlElements.A>
+          </View>
+        }>
+        {status === SupportStatus.Supported && 'Supports New Architecture'}
+        {status === SupportStatus.Unsupported && 'Does not support New Architecture'}
+        {status === SupportStatus.Untested && 'Untested with New Architecture'}
+        {typeof library.newArchitecture === 'string' && (
+          <>
+            <Label style={styles.note}>{library.newArchitecture}</Label>
+          </>
+        )}
+      </Tooltip>
+    </View>
+  );
+}
+
+function getSupportStatus({ newArchitecture, github }: Library, hasNote: boolean) {
+  if (hasNote) {
+    return SupportStatus.Supported;
+  }
+
+  const flag =
+    newArchitecture !== undefined
+      ? newArchitecture
+      : github.newArchitecture === true
+        ? true
+        : undefined;
+
+  switch (flag) {
+    case true:
+      return SupportStatus.Supported;
+    case false:
+      return SupportStatus.Unsupported;
+    default:
+      return SupportStatus.Untested;
+  }
+}
+
+function getIconColor(status: SupportStatus, isDark: boolean) {
+  switch (status) {
+    case SupportStatus.Supported:
+      return colors.primaryDark;
+    case SupportStatus.Unsupported:
+      return isDark ? darkColors.warning : colors.warningDark;
+    default:
+      return colors.gray5;
+  }
+}
+
+function getTagColor(status: SupportStatus, isDark: boolean) {
+  switch (status) {
+    case SupportStatus.Supported:
+      return {
+        backgroundColor: isDark ? '#142933' : '#e8f6fc',
+        borderColor: isDark ? '#1e4047' : '#cdedf7',
+      };
+    case SupportStatus.Unsupported:
+      return {
+        backgroundColor: isDark ? darkColors.warningLight : '#fffae0',
+        borderColor: isDark ? '#3d3306' : '#fcee9d',
+      };
+    default:
+      return {
+        backgroundColor: isDark ? darkColors.dark : colors.gray1,
+        borderColor: isDark ? darkColors.border : colors.gray2,
+      };
+  }
+}
+
+const styles = StyleSheet.create({
+  note: {
+    display: 'flex',
+    marginTop: 4,
+    color: '#fff',
+  },
+});

--- a/components/Library/UnmaintainedLabel.tsx
+++ b/components/Library/UnmaintainedLabel.tsx
@@ -8,7 +8,9 @@ import { Warning } from '../Icons';
 const UnmaintainedLabel = ({ value }) => {
   const { isDark } = useContext(CustomAppearanceContext);
   const { isSmallScreen } = useLayout();
+
   const linkHoverStyle = isDark && { color: colors.secondary };
+  const contentColor = isDark ? darkColors.secondary : colors.gray5;
 
   return (
     <View style={styles.unmaintainedTextWrapper}>
@@ -16,35 +18,27 @@ const UnmaintainedLabel = ({ value }) => {
         style={[
           styles.unmaintainedTextContainer,
           {
-            gap: 4,
             flexDirection: isSmallScreen ? 'column' : 'row',
-            backgroundColor: isDark ? darkColors.warningLight : colors.warningLight,
+            backgroundColor: isDark ? darkColors.dark : colors.gray1,
+            borderColor: isDark ? darkColors.border : colors.gray2,
+            // @ts-expect-error
+            backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 20px, ${isDark ? '#18181f' : '#f0f0f0'} 20px, ${isDark ? '#18181f' : '#f0f0f0'} 40px)`,
           },
         ]}>
-        <View
-          style={[
-            styles.unmaintainedTextWrapper,
-            {
-              gap: 6,
-            },
-          ]}>
-          <Warning width={16} height={16} fill={isDark ? darkColors.warning : colors.warningDark} />
+        <View style={styles.unmaintainedTextWrapper}>
+          <Warning width={16} height={16} fill={contentColor} />
           <Label
-            style={[
-              {
-                color: isDark ? darkColors.warning : colors.warningDark,
-              },
-            ]}>
+            style={{
+              color: contentColor,
+            }}>
             This library is not actively maintained.
           </Label>
         </View>
         {typeof value === 'string' && (
           <Label
-            style={[
-              {
-                color: isDark ? darkColors.warning : colors.warningDark,
-              },
-            ]}>
+            style={{
+              color: contentColor,
+            }}>
             You can use{' '}
             <A
               href={`/?search=${encodeURIComponent(value)}`}
@@ -63,6 +57,7 @@ const UnmaintainedLabel = ({ value }) => {
 const styles = StyleSheet.create({
   unmaintainedTextWrapper: {
     flexDirection: 'row',
+    gap: 6,
   },
   unmaintainedTextContainer: {
     alignItems: 'flex-start',
@@ -73,6 +68,9 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     borderTopRightRadius: 4,
     borderBottomRightRadius: 4,
+    gap: 4,
+    borderWidth: 1,
+    borderLeftWidth: 0,
   },
 });
 

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -42,6 +42,7 @@ const Library = ({ library, skipMeta, showPopularity }: Props) => {
         isSmallScreen && styles.containerColumn,
         skipMeta && styles.noMetaContainer,
         skipMeta && (isSmallScreen || isBelowMaxWidth) && styles.noMetaColumnContainer,
+        library.unmaintained && styles.unmaintained,
       ]}>
       <View style={styles.columnOne}>
         {library.unmaintained && <UnmaintainedLabel value={library.unmaintained} />}
@@ -50,7 +51,7 @@ const Library = ({ library, skipMeta, showPopularity }: Props) => {
           <A
             href={library.githubUrl || github.urls.repo}
             style={styles.name}
-            hoverStyle={styles.nameHovered}>
+            hoverStyle={{ color: isDark ? colors.gray3 : colors.gray5 }}>
             {libName}
           </A>
           {library.goldstar && <RecommendedLabel isSmallScreen={isSmallScreen} />}
@@ -149,9 +150,6 @@ const styles = StyleSheet.create({
     fontSize: 19,
     textDecorationLine: 'none',
   },
-  nameHovered: {
-    color: colors.gray4,
-  },
   displayHorizontal: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -223,6 +221,9 @@ const styles = StyleSheet.create({
     maxHeight: 'auto',
     width: '98.5%',
     maxWidth: '98.5%',
+  },
+  unmaintained: {
+    opacity: 0.88,
   },
 });
 

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -1,0 +1,48 @@
+import { ReactElement, useContext } from 'react';
+import { StyleSheet, View, ViewStyle } from 'react-native';
+
+import { Check } from './Icons';
+import { colors, darkColors, Label } from '../common/styleguide';
+import CustomAppearanceContext from '../context/CustomAppearanceContext';
+
+type Props = {
+  label: string;
+  tagStyle: ViewStyle;
+  icon?: ReactElement;
+};
+
+export const Tag = ({
+  label,
+  tagStyle,
+  icon = <Check width={12} height={8} fill={colors.gray5} />,
+}: Props) => {
+  const { isDark } = useContext(CustomAppearanceContext);
+  return (
+    <View key={label} style={[styles.tag, tagStyle]}>
+      {icon}
+      <Label
+        style={[
+          {
+            color: isDark ? darkColors.secondary : colors.black,
+          },
+        ]}>
+        {label}
+      </Label>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  tag: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    marginBottom: 4,
+    userSelect: 'none',
+    minHeight: 25.5,
+    gap: 5,
+  },
+});

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,18 +1,20 @@
+import { type PopperContentProps } from '@radix-ui/react-popper';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import type { PropsWithChildren, ReactNode } from 'react';
 
 type TooltipProps = PropsWithChildren<{
   trigger: ReactNode;
   sideOffset?: number;
+  side?: PopperContentProps['side'];
 }>;
 
-function Tooltip({ children, trigger, sideOffset = 4 }: TooltipProps) {
+function Tooltip({ children, trigger, side, sideOffset = 4 }: TooltipProps) {
   return (
     <TooltipPrimitive.Provider>
       <TooltipPrimitive.Root delayDuration={0}>
         <TooltipPrimitive.Trigger asChild>{trigger}</TooltipPrimitive.Trigger>
         <TooltipPrimitive.Portal>
-          <TooltipPrimitive.Content className="TooltipContent" sideOffset={sideOffset}>
+          <TooltipPrimitive.Content className="TooltipContent" sideOffset={sideOffset} side={side}>
             {children}
             <TooltipPrimitive.Arrow style={{ fill: '#000' }} />
           </TooltipPrimitive.Content>

--- a/debug-github-repos.json
+++ b/debug-github-repos.json
@@ -20,7 +20,11 @@
   { "githubUrl": "https://github.com/BugiDev/react-native-calendar-strip", "expoGo": true },
   { "githubUrl": "https://github.com/archriss/react-native-render-html", "expoGo": true },
   { "githubUrl": "https://github.com/react-native-community/react-native-picker", "expoGo": true },
-  { "githubUrl": "https://github.com/th3rdwave/react-native-safe-area-context", "expoGo": true },
+  {
+    "githubUrl": "https://github.com/th3rdwave/react-native-safe-area-context",
+    "expoGo": true,
+    "template": true
+  },
   {
     "githubUrl": "https://github.com/react-native-datetimepicker/datetimepicker",
     "npmPkg": "@react-native-community/datetimepicker",

--- a/debug-github-repos.json
+++ b/debug-github-repos.json
@@ -1,9 +1,14 @@
 [
   {
     "githubUrl": "https://github.com/react-community/react-navigation",
-    "expoGo": true
+    "expoGo": true,
+    "newArchitecture": true
   },
-  { "githubUrl": "https://github.com/gre/gl-react", "expoGo": true },
+  {
+    "githubUrl": "https://github.com/gre/gl-react",
+    "expoGo": true,
+    "newArchitecture": false
+  },
   {
     "githubUrl": "https://github.com/expo/expo/tree/main/packages/expo-barcode-scanner",
     "expoGo": true,
@@ -22,5 +27,9 @@
     "expoGo": true,
     "newArchitecture": "Test note for new architecture support"
   },
-  { "githubUrl": "https://github.com/rnc-archive/react-native-drawer-layout", "expoGo": true }
+  {
+    "githubUrl": "https://github.com/rnc-archive/react-native-drawer-layout",
+    "expoGo": true,
+    "dev": true
+  }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

This PR converts the New Architecture metadata entry, to more prominent compatibility tag. The ability to add the note (so `string` value) has been retained.

The `newArchitecture` status now will have three states:
* supported: user sets the flag value to `true`, user sets the value to `string` or automatic detection returns `true`
* unsupported: user sets the flag value to `false`
* untested: flag is not set, flag is set to `undefined` or automatic detection returns `false`

Additionally, I have made few tweaks to the `Tag` and `Tooltip` components in the process.

After few iterations I have also altered the `UnmaintainedTag` appearance to reduce the multiple colors crush.

# Preview

Deployment: https://react-native-directory-i50675av2-rndir.vercel.app/

![Screenshot 2024-07-17 at 20 42 47](https://github.com/user-attachments/assets/79d4cc2f-8c69-4173-b940-97e42feb0177)
![Screenshot 2024-07-17 at 20 41 39](https://github.com/user-attachments/assets/7cbf0ca0-3d9f-4e24-91bc-6fa5a899e297)

![Screenshot 2024-07-17 at 21 32 44](https://github.com/user-attachments/assets/9f2808c3-c8dc-424b-a4b7-a87754a0c10d)
![Screenshot 2024-07-17 at 21 31 21](https://github.com/user-attachments/assets/ef075707-a807-4c25-95e6-8615e278d654)

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [x] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
