### PR TITLE
Support filtering by not supported and untested with new arch

### DIFF
--- a/components/Library/NewArchitectureTag.tsx
+++ b/components/Library/NewArchitectureTag.tsx
@@ -5,6 +5,10 @@ import { View, StyleSheet } from 'react-native';
 import { colors, darkColors, Label } from '../../common/styleguide';
 import CustomAppearanceContext from '../../context/CustomAppearanceContext';
 import { Library } from '../../types';
+import {
+  getNewArchSupportStatus as getSupportStatus,
+  NewArchSupportStatus as SupportStatus,
+} from '../../util/newArchStatus';
 import { Check, Question, XIcon } from '../Icons';
 import { Tag } from '../Tag';
 import Tooltip from '../Tooltip';
@@ -13,17 +17,9 @@ type Props = {
   library: Library;
 };
 
-enum SupportStatus {
-  Supported = 'supported',
-  Unsupported = 'unsupported',
-  Untested = 'untested',
-}
-
 export function NewArchitectureTag({ library }: Props) {
   const { isDark } = useContext(CustomAppearanceContext);
-
-  const hasNote = typeof library.newArchitecture === 'string';
-  const status = getSupportStatus(library, hasNote);
+  const status = getSupportStatus(library);
 
   const icon =
     status === SupportStatus.Unsupported ? (
@@ -58,28 +54,6 @@ export function NewArchitectureTag({ library }: Props) {
       </Tooltip>
     </View>
   );
-}
-
-function getSupportStatus({ newArchitecture, github }: Library, hasNote: boolean) {
-  if (hasNote) {
-    return SupportStatus.Supported;
-  }
-
-  const flag =
-    newArchitecture !== undefined
-      ? newArchitecture
-      : github.newArchitecture === true
-        ? true
-        : undefined;
-
-  switch (flag) {
-    case true:
-      return SupportStatus.Supported;
-    case false:
-      return SupportStatus.Unsupported;
-    default:
-      return SupportStatus.Untested;
-  }
 }
 
 function getIconColor(status: SupportStatus, isDark: boolean) {

--- a/util/newArchStatus.ts
+++ b/util/newArchStatus.ts
@@ -1,0 +1,30 @@
+import { Library } from '../types';
+
+export enum NewArchSupportStatus {
+  Supported = 'supported',
+  Unsupported = 'unsupported',
+  Untested = 'untested',
+}
+
+export function getNewArchSupportStatus({ newArchitecture, github }: Library) {
+  const hasNote = typeof newArchitecture === 'string';
+  if (hasNote) {
+    return NewArchSupportStatus.Supported;
+  }
+
+  const flag =
+    newArchitecture !== undefined
+      ? newArchitecture
+      : github.newArchitecture === true
+        ? true
+        : undefined;
+
+  switch (flag) {
+    case true:
+      return NewArchSupportStatus.Supported;
+    case false:
+      return NewArchSupportStatus.Unsupported;
+    default:
+      return NewArchSupportStatus.Untested;
+  }
+}

--- a/util/search.js
+++ b/util/search.js
@@ -1,3 +1,4 @@
+import { getNewArchSupportStatus, NewArchSupportStatus } from './newArchStatus';
 import { isEmptyOrNull } from './strings';
 
 const calculateMatchScore = ({ github, npmPkg, topicSearchString, unmaintained }, querySearch) => {
@@ -113,7 +114,26 @@ export const handleFilterLibraries = ({
       return false;
     }
 
-    if (newArchitecture && !library.newArchitecture && !library.github.newArchitecture) {
+    const newArchStatus = getNewArchSupportStatus(library);
+
+    if (
+      newArchitecture === 'true' &&
+      [NewArchSupportStatus.Unsupported, NewArchSupportStatus.Untested].includes(newArchStatus)
+    ) {
+      return false;
+    }
+
+    if (
+      newArchitecture === 'false' &&
+      [NewArchSupportStatus.Supported, NewArchSupportStatus.Untested].includes(newArchStatus)
+    ) {
+      return false;
+    }
+
+    if (
+      newArchitecture === 'untested' &&
+      [NewArchSupportStatus.Supported, NewArchSupportStatus.Unsupported].includes(newArchStatus)
+    ) {
       return false;
     }
 


### PR DESCRIPTION
# 📝 Why & how

I find this useful to have, maybe we expose it in the UI eventually. Similar idea to #1199.

I pulled new arch status detection into a util to reuse in search filters.