### PR TITLE
Add newArchitectureNote and alternatives fields, update data and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,16 +123,24 @@
 #### 🏷️ Tags
 
 - #### `unmaintained`
-  **(boolean|string)** - signify that a library is no longer maintained. Can also pass the package name string to point out the recommended alternative.
+  **(boolean)** - signify that a library is no longer maintained. Provide alternative libraries with the `alternatives` field.
 - #### `dev`
   **(boolean)** - signify that a library is a development tool or is only a part of development process.
 - #### `template`
   **(boolean)** - signify that a library is a new project template.
 - #### `newArchitecture`
 
-  **(boolean)** - signify that a library supports, or not, the new architecture. Skipping the field will result in "untested" status, unless automatic support detection returned a result. 
+  **(boolean)** - signify that a library supports, or not, the New Architecture. Skipping the field will result in "untested" status, unless automatic support detection returned a result.  Provide additional context with the `newArchitectureNote` field.
 
-  > Set this tag only when automatic architecture detection fails for your package, despite it supports the new architecture.
+  > Set this tag only when automatic architecture detection fails for your package, despite it supports the New Architecture.
+
+### 📝 Additional context for tags
+
+- #### `newArchitectureNote`
+  **(string)** - provide a note for the New Architecture support status, if a boolean `"true"` or `"false"` is not sufficient to describe the state of New Architecture support.
+
+- #### `alternatives`
+  **(array of strings)** - provide a list of alternatives to the library. eg: `["expo-camera", "react-native-vision-camera"]`. This is used to provide a list of alternatives to a library if it is unmaintained or does not suppport the New Architecture.
 
 ---
 

--- a/components/Library/NewArchitectureTag.tsx
+++ b/components/Library/NewArchitectureTag.tsx
@@ -46,9 +46,15 @@ export function NewArchitectureTag({ library }: Props) {
         {status === SupportStatus.Supported && 'Supports New Architecture'}
         {status === SupportStatus.Unsupported && 'Does not support New Architecture'}
         {status === SupportStatus.Untested && 'Untested with New Architecture'}
-        {typeof library.newArchitecture === 'string' && (
+        {typeof library.newArchitectureNote === 'string' && (
           <>
-            <Label style={styles.note}>{library.newArchitecture}</Label>
+            <Label style={styles.note}>{library.newArchitectureNote}</Label>
+            {library.alternatives && library.alternatives.length > 0 && (
+              <Label style={styles.note}>
+                {library.alternatives.length > 1 ? 'Alternatives:' : 'Alternative:'}{' '}
+                {library.alternatives.join(', ')}
+              </Label>
+            )}
           </>
         )}
       </Tooltip>
@@ -90,7 +96,7 @@ function getTagColor(status: SupportStatus, isDark: boolean) {
 const styles = StyleSheet.create({
   note: {
     display: 'flex',
-    marginTop: 4,
+    marginVertical: 4,
     color: '#fff',
   },
 });

--- a/components/Library/UnmaintainedLabel.tsx
+++ b/components/Library/UnmaintainedLabel.tsx
@@ -5,7 +5,7 @@ import { A, colors, darkColors, Label, useLayout } from '../../common/styleguide
 import CustomAppearanceContext from '../../context/CustomAppearanceContext';
 import { Warning } from '../Icons';
 
-const UnmaintainedLabel = ({ value }) => {
+const UnmaintainedLabel = ({ alternatives }) => {
   const { isDark } = useContext(CustomAppearanceContext);
   const { isSmallScreen } = useLayout();
 
@@ -34,18 +34,25 @@ const UnmaintainedLabel = ({ value }) => {
             This library is not actively maintained.
           </Label>
         </View>
-        {typeof value === 'string' && (
+        {alternatives && alternatives.length > 0 && (
           <Label
             style={{
               color: contentColor,
             }}>
             You can use{' '}
-            <A
-              href={`/?search=${encodeURIComponent(value)}`}
-              style={{ backgroundColor: 'transparent' }}
-              hoverStyle={linkHoverStyle}>
-              {value}
-            </A>{' '}
+            {alternatives.map((alternative, index) => (
+              <>
+                <A
+                  key={alternative}
+                  href={`/?search=${encodeURIComponent(alternative)}`}
+                  style={{ backgroundColor: 'transparent' }}
+                  hoverStyle={linkHoverStyle}>
+                  {alternative}
+                </A>
+                {index < alternatives.length - 1 && alternatives.length > 2 ? ', ' : ' '}
+                {index === alternatives.length - 2 && 'or '}
+              </>
+            ))}{' '}
             instead.
           </Label>
         )}

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -45,7 +45,7 @@ const Library = ({ library, skipMeta, showPopularity }: Props) => {
         library.unmaintained && styles.unmaintained,
       ]}>
       <View style={styles.columnOne}>
-        {library.unmaintained && <UnmaintainedLabel value={library.unmaintained} />}
+        {library.unmaintained && <UnmaintainedLabel alternatives={library.alternatives} />}
         {showPopularity && library.popularity && <PopularityMark library={library} />}
         <View style={isSmallScreen ? styles.containerColumn : styles.displayHorizontal}>
           <A

--- a/debug-github-repos.json
+++ b/debug-github-repos.json
@@ -29,7 +29,8 @@
     "githubUrl": "https://github.com/react-native-datetimepicker/datetimepicker",
     "npmPkg": "@react-native-community/datetimepicker",
     "expoGo": true,
-    "newArchitecture": "Test note for new architecture support"
+    "newArchitecture": true,
+    "newArchitectureNote": "Test note for New Architecture support"
   },
   {
     "githubUrl": "https://github.com/rnc-archive/react-native-drawer-layout",

--- a/pages/scoring.tsx
+++ b/pages/scoring.tsx
@@ -114,7 +114,7 @@ const Scoring = () => {
           Libraries that have been updated in the last 30 days meet this criterion.
         </ScoringCriterion>
         <ScoringCriterion headline="Not supporting New Architecture" score={-5}>
-          Libraries that does not support new architecture meet this criterion.
+          Libraries that does not support New Architecture meet this criterion.
         </ScoringCriterion>
         <ScoringCriterion headline="Not updated recently" score={-10}>
           Libraries that have not been updated in the last 180 days meet this criterion.

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -87,7 +87,9 @@
     ],
     "ios": true,
     "android": true,
-    "expoGo": true
+    "expoGo": true,
+    "newArchitecture": true,
+    "newArchitectureNote": "Works used with Expo modules dependencies. Alternative dependencies are not all compatible with the New Architecture."
   },
   {
     "githubUrl": "https://github.com/alexfoxy/react-native-units",
@@ -1695,7 +1697,8 @@
     "githubUrl": "https://github.com/AlexanderZaytsev/react-native-i18n",
     "ios": true,
     "android": true,
-    "unmaintained": "react-native-localize"
+    "unmaintained": true,
+    "alternatives": ["react-native-localize"]
   },
   {
     "githubUrl": "https://github.com/Anthonyzou/react-native-image-zoom",
@@ -2016,7 +2019,6 @@
     "githubUrl": "https://github.com/Polidea/react-native-ble-plx",
     "ios": true,
     "android": true,
-    "expoGo": true,
     "newArchitecture": true
   },
   {
@@ -2164,7 +2166,8 @@
     "githubUrl": "https://github.com/itinance/react-native-fs",
     "ios": true,
     "android": true,
-    "unmaintained": "expo-file-system"
+    "unmaintained": true,
+    "alternatives": ["expo-file-system"]
   },
   {
     "githubUrl": "https://github.com/lodev09/react-native-cell-components",
@@ -3499,7 +3502,8 @@
     "tvos": true,
     "web": true,
     "expoGo": true,
-    "unmaintained": "react-native-safe-area-context"
+    "unmaintained": true,
+    "alternatives": ["react-native-safe-area-context"]
   },
   {
     "githubUrl": "https://github.com/Kureev/react-native-blur",
@@ -3831,7 +3835,8 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "unmaintained": "expo"
+    "unmaintained": true,
+    "alternatives": ["expo-modules-core"]
   },
   {
     "githubUrl": "https://github.com/codemotionapps/react-native-dark-mode",
@@ -3847,7 +3852,9 @@
     ],
     "ios": true,
     "android": true,
-    "unmaintained": "expo-image"
+    "newArchitecture": false,
+    "unmaintained": true,
+    "alternatives": ["expo-image"]
   },
   {
     "githubUrl": "https://github.com/ascoders/react-native-image-viewer",
@@ -4194,7 +4201,9 @@
     "android": true,
     "windows": true,
     "newArchitecture": false,
-    "unmaintained": "expo-updates"
+    "newArchitectureNote": "Microsoft no longer maintains this library and has no plans to add New Architecture support.",
+    "unmaintained": true,
+    "alternatives": ["expo-updates"]
   },
   {
     "githubUrl": "https://github.com/plmok61/react-navigation-transitions",
@@ -5175,7 +5184,8 @@
     ],
     "ios": true,
     "android": true,
-    "unmaintained": "expo-local-authentication"
+    "unmaintained": true,
+    "alternatives": ["expo-local-authentication"]
   },
   {
     "githubUrl": "https://github.com/react-native-google-cast/react-native-google-cast",
@@ -5193,7 +5203,8 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "unmaintained": "react-native-reanimated-table"
+    "unmaintained": true,
+    "alternatives": ["react-native-reanimated-table"]
   },
   {
     "githubUrl": "https://github.com/codemotionapps/react-native-dynamic",
@@ -6004,7 +6015,8 @@
     "ios": true,
     "android": true,
     "visionos": true,
-    "npmPkg": "@react-native-menu/menu"
+    "npmPkg": "@react-native-menu/menu",
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/dominicstop/react-native-ios-context-menu",
@@ -6355,8 +6367,7 @@
       "https://raw.githubusercontent.com/mrousavy/react-native-vision-camera/main/docs/static/img/demo.gif"
     ],
     "ios": true,
-    "android": true,
-    "expoGo": true
+    "android": true
   },
   {
     "githubUrl": "https://github.com/dabakovich/react-native-controlled-mentions",
@@ -8405,7 +8416,8 @@
     "npmPkg": "@shopify/flash-list",
     "android": true,
     "ios": true,
-    "expoGo": true
+    "expoGo": true,
+    "newArchitectureNote": "Compiles and runs, but behavior may not be as expected."
   },
   {
     "githubUrl": "https://github.com/callstack/reassure",

--- a/react-native-libraries.schema.json
+++ b/react-native-libraries.schema.json
@@ -8,14 +8,18 @@
     "$id": "#/items",
     "type": "object",
     "title": "The Items Schema",
-    "required": ["githubUrl"],
+    "required": [
+      "githubUrl"
+    ],
     "properties": {
       "githubUrl": {
         "$id": "#/items/properties/githubUrl",
         "type": "string",
         "title": "The GitHub URL Schema",
         "default": "",
-        "examples": ["https://github.com/joshswan/react-native-autolink"],
+        "examples": [
+          "https://github.com/joshswan/react-native-autolink"
+        ],
         "pattern": "^(.*)$"
       },
       "ios": {
@@ -23,35 +27,45 @@
         "type": "boolean",
         "title": "The iOS Schema",
         "default": false,
-        "examples": [true]
+        "examples": [
+          true
+        ]
       },
       "android": {
         "$id": "#/items/properties/android",
         "type": "boolean",
         "title": "The Android Schema",
         "default": false,
-        "examples": [true]
+        "examples": [
+          true
+        ]
       },
       "windows": {
         "$id": "#/items/properties/windows",
         "type": "boolean",
         "title": "The Windows Schema",
         "default": false,
-        "examples": [true]
+        "examples": [
+          true
+        ]
       },
       "macos": {
         "$id": "#/items/properties/macos",
         "type": "boolean",
         "title": "The macOS Schema",
         "default": false,
-        "examples": [true]
+        "examples": [
+          true
+        ]
       },
       "expoGo": {
         "$id": "#/items/properties/expo",
         "type": "boolean",
         "title": "The Expo Go Schema",
         "default": false,
-        "examples": [true]
+        "examples": [
+          true
+        ]
       },
       "examples": {
         "$id": "#/items/properties/examples",
@@ -63,7 +77,9 @@
           "type": "string",
           "title": "The Items Schema",
           "default": "",
-          "examples": ["https://snack.expo.io/SkRP2Ehrb"],
+          "examples": [
+            "https://snack.expo.io/SkRP2Ehrb"
+          ],
           "pattern": "^(.*)$"
         }
       },
@@ -72,27 +88,39 @@
         "type": "string",
         "title": "The NPM Package Name Schema",
         "default": "",
-        "examples": ["@expo/ex-navigation"],
+        "examples": [
+          "@expo/ex-navigation"
+        ],
         "pattern": "^(@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*$"
       },
       "unmaintained": {
         "$id": "#/items/properties/unmaintained",
-        "type": ["boolean", "string"],
+        "type": [
+          "boolean",
+          "string"
+        ],
         "title": "The Unmaintained Schema",
         "default": false,
-        "examples": [true, "expo-image"]
+        "examples": [
+          true,
+          "expo-image"
+        ]
       },
       "images": {
         "$id": "#/items/properties/images",
         "type": "array",
         "title": "The Images Schema",
-        "default": [null],
+        "default": [
+          null
+        ],
         "items": {
           "$id": "#/items/properties/images/items",
           "type": "string",
           "title": "The Image Schema",
           "default": "",
-          "examples": ["https://reactnative.dev/img/homepage/phones.png"],
+          "examples": [
+            "https://reactnative.dev/img/homepage/phones.png"
+          ],
           "pattern": "^(http(s?):)(\\w|\\/|\\.|:|-|%|\\+|\\*)+\\.(?:jp(e?)g|gif|png|webp|JP(E?)G|GIF|PNG|WEBP)$"
         }
       },
@@ -101,7 +129,9 @@
         "type": "string",
         "title": "Optional property to override the name provided by npm and GitHub",
         "default": "",
-        "examples": ["react-navigation"],
+        "examples": [
+          "react-navigation"
+        ],
         "pattern": "^(.*)$"
       },
       "dev": {
@@ -109,21 +139,58 @@
         "type": "boolean",
         "title": "The Development Tool Schema",
         "default": false,
-        "examples": [true]
+        "examples": [
+          true
+        ]
       },
       "template": {
         "$id": "#/items/properties/template",
         "type": "boolean",
         "title": "The Template Schema",
         "default": false,
-        "examples": [true]
+        "examples": [
+          true
+        ]
       },
       "newArchitecture": {
         "$id": "#/items/properties/newArchitecture",
-        "type": ["boolean", "string"],
+        "type": [
+          "boolean",
+          "string"
+        ],
         "title": "The New Architecture Support Schema",
         "default": false,
-        "examples": [true, "Only iOS supported"]
+        "examples": [
+          true,
+          "Only iOS supported"
+        ]
+      },
+      "newArchitectureNote": {
+        "$id": "#/items/properties/newArchitectureNote",
+        "type": "string",
+        "title": "Optional note about the New Architecture support",
+        "default": "",
+        "examples": [
+          "Refer to https://github.com/MinaSamir11/react-native-in-app-review/issues/169 for the latest status"
+        ]
+      },
+      "alternatives": {
+        "$id": "#/items/properties/alternatives",
+        "type": "array",
+        "title": "Optional alternative libraries to use, if the library is not maintained anymore or does not support the New Architecture",
+        "default": [
+          null
+        ],
+        "items": {
+          "$id": "#/items/properties/alternatives/items",
+          "type": "string",
+          "title": "Alternative library",
+          "default": "",
+          "examples": [
+            "expo-image"
+          ],
+          "pattern": "^(@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*$"
+        }
       }
     }
   }

--- a/types/index.ts
+++ b/types/index.ts
@@ -51,6 +51,8 @@ export type Library = {
   dev?: boolean;
   template?: boolean;
   newArchitecture?: boolean | string;
+  newArchitectureNote?: string;
+  alternatives?: string[];
   github: {
     urls: {
       repo: string;

--- a/util/newArchStatus.ts
+++ b/util/newArchStatus.ts
@@ -7,11 +7,6 @@ export enum NewArchSupportStatus {
 }
 
 export function getNewArchSupportStatus({ newArchitecture, github, expoGo }: Library) {
-  const hasNote = typeof newArchitecture === 'string';
-  if (hasNote) {
-    return NewArchSupportStatus.Supported;
-  }
-
   // Assume untested unless indicated otherwise through one of the following tests
   let flag = undefined;
 
@@ -20,7 +15,7 @@ export function getNewArchSupportStatus({ newArchitecture, github, expoGo }: Lib
   } else if (github.newArchitecture === true) {
     flag = true;
   } else if (expoGo === true) {
-    // If the library is an Expo Go library, we consider it as supporting new architecture because
+    // If the library is an Expo Go library, we consider it as supporting New Architecture because
     // it is either part of the Expo SDK (and therefore supports it) or it is a JS library that
     // does not depend on custom native code. In any cases where this doesn't prove to be true,
     // we can override it with the newArchitecture field.


### PR DESCRIPTION
# 📝 Why & how

- I wanted to split out the alternative libraries from `unmaintained`, since we can use it for both unmaintained and new arch options - and perhaps further cases in the future. I also wanted to support listing multiple alternatives.
- I wanted to split out the new arch note from `newArchitecture` because I want to add notes regardless of the supported state (true/false/untested).
- I updated the data and UI accordingly.

Check it out on the preview.

# ✅ Checklist

- [x] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
