### PR TITLE
increase stagger time for bulk GH queries

### DIFF
--- a/scripts/build-and-score-data.js
+++ b/scripts/build-and-score-data.js
@@ -253,7 +253,7 @@ async function loadRepositoryDataAsync() {
     result = fs.readFileSync(GITHUB_RESULTS_PATH);
     console.log('Loaded Github results from disk, skipped API calls');
   } else {
-    result = await fetchGithubDataThrottled({ data, chunkSize: 25, staggerMs: 3000 });
+    result = await fetchGithubDataThrottled({ data, chunkSize: 25, staggerMs: 5000 });
 
     if (LOAD_GITHUB_RESULTS_FROM_DISK) {
       fs.writeFileSync(GITHUB_RESULTS_PATH, JSON.stringify(result, null, 2));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

From time to time we got a timeouts for several libraries or bad responses from GitHub API, let's increaser the stagger for bulk queries back to 5s and see if this improves stability.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [s] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
