### PR TITLE
add ability to fetch data for a single package

### DIFF
--- a/scripts/calculate-score.js
+++ b/scripts/calculate-score.js
@@ -5,7 +5,7 @@
 // This is an array of modifier objects. Each modifier has a name, value, and condition.
 // The data is passed to condition function, and if it returns true, the value is added to the
 // libraries score. Read more: https://reactnative.directory/scoring
-const modifiers = [
+const MODIFIERS = [
   {
     name: 'Very popular',
     value: 40,
@@ -56,17 +56,20 @@ const modifiers = [
   },
 ];
 
+const DAY_IN_MS = 864e5;
+
 // Calculate the minimum and maximum possible scores based on the modifiers
-const minScore = modifiers.reduce((currentMin, modifier) => {
+const minScore = MODIFIERS.reduce((currentMin, modifier) => {
   return modifier.value < 0 ? currentMin + modifier.value : currentMin;
 }, 0);
-const maxScore = modifiers.reduce((currentMax, modifier) => {
+
+const maxScore = MODIFIERS.reduce((currentMax, modifier) => {
   return modifier.value > 0 ? currentMax + modifier.value : currentMax;
 }, 0);
 
 export const calculateDirectoryScore = data => {
   // Filter the modifiers to the ones which conditions pass with the data
-  const matchingModifiers = modifiers.filter(modifier => modifier.condition(data));
+  const matchingModifiers = MODIFIERS.filter(modifier => modifier.condition(data));
 
   // Reduce the matching modifiers to find the raw score for the data
   const rawScore = matchingModifiers.reduce((currentScore, modifier) => {
@@ -92,8 +95,6 @@ const getCombinedPopularity = data => {
   const { downloads } = data.npm;
   return subscribers * 20 + forks * 10 + stars + downloads / 100;
 };
-
-const DAY_IN_MS = 864e5;
 
 const getUpdatedDaysAgo = data => {
   const { updatedAt } = data.github.stats;

--- a/scripts/fetch-npm-data.js
+++ b/scripts/fetch-npm-data.js
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch';
 
-import { sleep } from './build-and-score-data.js';
+import { sleep } from './helpers.js';
 
 const urlForPackage = (npmPkg, period = 'month') => {
   return `https://api.npmjs.org/downloads/point/last-${period}/${npmPkg}`;
@@ -8,13 +8,15 @@ const urlForPackage = (npmPkg, period = 'month') => {
 
 export const fetchNpmDataBulk = async (namesArray, period = 'month', attemptsCount = 0) => {
   try {
+    const listCount = namesArray.length;
     const url = urlForPackage(namesArray.join(','), period);
+
     const isMonthly = period === 'month';
     const response = await fetch(url);
     const downloadData = await response.json();
 
     return namesArray.map(name => {
-      const pkgData = downloadData[name];
+      const pkgData = listCount === 1 ? downloadData : downloadData[name];
 
       if (isMonthly && !pkgData?.downloads) {
         console.warn(

--- a/scripts/fetch-readme-images.js
+++ b/scripts/fetch-readme-images.js
@@ -1,7 +1,7 @@
 import { load } from 'cheerio';
 import fetch from 'cross-fetch';
 
-import { sleep } from './build-and-score-data.js';
+import { sleep } from './helpers.js';
 
 const isLikelyUsefulImage = (image, imageSrc, githubUrl) => {
   const parentHref = image.parent().attr('href');

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,0 +1,25 @@
+export function sleep(ms = 0, msMax = null) {
+  return new Promise(r =>
+    setTimeout(r, msMax ? Math.floor(Math.random() * (msMax - ms)) + ms : ms)
+  );
+}
+
+export function fillNpmName(project) {
+  if (!project.npmPkg) {
+    const parts = project.githubUrl.split('/');
+    project.npmPkg = parts[parts.length - 1].toLowerCase();
+  }
+  return project;
+}
+
+export function processTopics(topics) {
+  return (topics || [])
+    .map(topic =>
+      topic
+        .replace(/([ _])/g, '-')
+        .replace('react-native-', '')
+        .toLowerCase()
+        .trim()
+    )
+    .filter(topic => topic?.length);
+}

--- a/scripts/queries/GitHubLicensesQuery.js
+++ b/scripts/queries/GitHubLicensesQuery.js
@@ -1,0 +1,13 @@
+const GitHubLicensesQuery = `
+    query {
+      licenses {
+        name
+        url
+        id
+        key
+        spdxId
+      }
+    }
+  `;
+
+export default GitHubLicensesQuery;

--- a/scripts/queries/GitHubRepositoryQuery.js
+++ b/scripts/queries/GitHubRepositoryQuery.js
@@ -1,0 +1,81 @@
+const GitHubRepositoryQuery = `
+  query ($repoOwner: String!, $repoName: String!, $packagePath: String = ".", $packageJsonPath: String = "HEAD:package.json") {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+    repository(owner: $repoOwner, name: $repoName) {
+      hasIssuesEnabled
+      hasWikiEnabled
+      hasSponsorshipsEnabled
+      issues(states: OPEN) {
+        totalCount
+      }
+      watchers {
+        totalCount
+      }
+      stargazers {
+        totalCount
+      }
+      forks {
+        totalCount
+      }
+      description
+      createdAt
+      pushedAt
+      updatedAt
+      homepageUrl
+      url
+      mirrorUrl
+      name
+      nameWithOwner
+      isArchived
+      isMirror
+      licenseInfo {
+        key
+        name
+        spdxId
+        url
+        id
+      }
+      releases(first: 1, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes {
+          name
+          tagName
+          createdAt
+          publishedAt
+          isPrerelease
+        }
+      }
+      repositoryTopics(first: 10) {
+        nodes {
+          topic {
+            name
+          }
+        }
+      }
+      defaultBranchRef {
+        target {
+          ... on Commit {
+            id
+            history(path: $packagePath, first: 1) {
+              nodes {
+                committedDate
+                message
+              }
+            }
+          }
+        }
+      }
+      packageJson:object(expression: $packageJsonPath) {
+        ... on Blob {
+          text
+        }
+      }
+    }
+  }
+`;
+
+export default GitHubRepositoryQuery;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

When adding new libraries or updating the existing entries it would be handy to be able to download/refresh the data only for that package, instead of downloading the whole set, or using debug repositories list.

This PR adds that ability to the already existing `data:update` script which can now accept a npm package name as an argument. For example, the following command will only updated the given package name in `assets/data.json` results file:
```sh
yarn data:update expo-image
```

Additionally, I have aggregated few helpers in a file and extracted the GitHub GQL API queries to separate files, mainly to improve the scripts readability.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [x] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
