### PR TITLE
Add @mattermost/react-native-paste-input

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -11536,5 +11536,17 @@
     ],
     "android": true,
     "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/mattermost/react-native-paste-input",
+    "npmPkg": "@mattermost/react-native-paste-input",
+    "examples": ["https://github.com/mattermost/react-native-paste-input/tree/master/example"],
+    "images": [
+      "https://github.com/mattermost/react-native-paste-input/blob/master/example/gifs/AndroidPasteInput.gif?raw=true",
+      "https://github.com/mattermost/react-native-paste-input/blob/master/example/gifs/iOSPasteInput.gif?raw=true"
+    ],
+    "newArchitecture": true,
+    "android": true,
+    "ios": true
   }
 ]

--- a/react-native-libraries.schema.json
+++ b/react-native-libraries.schema.json
@@ -119,9 +119,10 @@
           "title": "The Image Schema",
           "default": "",
           "examples": [
-            "https://reactnative.dev/img/homepage/phones.png"
+            "https://reactnative.dev/img/homepage/phones.png",
+            "https://github.com/mattermost/react-native-paste-input/blob/master/example/gifs/iOSPasteInput.gif?raw=true"
           ],
-          "pattern": "^(http(s?):)(\\w|\\/|\\.|:|-|%|\\+|\\*)+\\.(?:jp(e?)g|gif|png|webp|JP(E?)G|GIF|PNG|WEBP)$"
+          "pattern": "^(http(s?):)(\\w|\\/|\\.|:|-|%|\\+|\\*)+\\.(?:jp(e?)g|gif|png|webp|JP(E?)G|GIF|PNG|WEBP)(\\?\\S*)?$"
         }
       },
       "nameOverride": {


### PR DESCRIPTION
# 📝 Why & how

- Add https://github.com/mattermost/react-native-paste-input - I tested it against new architecture
- Updated libraries schema to support query params, so I can use the ?raw=true param (if you right click an image on GitHub and copy URL, this is what you will get - try it here: https://github.com/mattermost/react-native-paste-input/blob/master/example/gifs/iOSPasteInput.gif

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
