### PR TITLE
update: react-native-quick-crypto

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -10990,9 +10990,12 @@
   },
   {
     "githubUrl": "https://github.com/margelo/react-native-quick-crypto",
+    "npmPkg": "react-native-quick-crypto",
     "examples": ["https://github.com/margelo/react-native-quick-crypto/tree/main/example"],
     "ios": true,
-    "android": true
+    "android": true,
+    "newArchitecture": true,
+    "newArchitectureNote": "use v1.0.0 or higher for new architecture support"
   },
   {
     "githubUrl": "https://github.com/vokhuyetOz/react-native-messy",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -10989,13 +10989,13 @@
     "expoGo": true
   },
   {
-    "githubUrl": "https://github.com/margelo/react-native-quick-crypto",
+    "githubUrl": "https://github.com/margelo/react-native-quick-crypto/tree/main/packages/react-native-quick-crypto",
     "npmPkg": "react-native-quick-crypto",
     "examples": ["https://github.com/margelo/react-native-quick-crypto/tree/main/example"],
     "ios": true,
     "android": true,
     "newArchitecture": true,
-    "newArchitectureNote": "use v1.0.0 or higher for new architecture support"
+    "newArchitectureNote": "Use v1.0.0 or higher for new architecture support"
   },
   {
     "githubUrl": "https://github.com/vokhuyetOz/react-native-messy",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
I wasn't seeing the `react-native-quick-crypto` library in the directory while searching for `crypto` or `quick`.  So I'm wondering if that was because it was missing the `npmPkg` field.

I added that field and a couple of others, as `v1.0.0` and higher supports new architecture.

If this doesn't fix the library not appearing in search or the directory in general, can a maintainer weigh in on what needs to change?  🙏 


# ✅ Checklist
- [x] Updated library in **`react-native-libraries.json`**
- [x] Documented in this PR how you fixed or created the feature.
