### PR TITLE
Feat/update intercom in React Native Librairies

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1737,6 +1737,11 @@
     "android": true
   },
   {
+    "githubUrl": "https://github.com/tinycreative/react-native-intercom",
+    "ios": true,
+    "android": true
+  },
+  {
     "githubUrl": "https://github.com/joshswan/react-native-globalize",
     "ios": true,
     "android": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -11899,5 +11899,26 @@
     "expoGo": true,
     "macos": true,
     "newArchitecture": true
+  }, 
+  {
+    "githubUrl": "https://github.com/intercom/intercom-react-native",
+    "npmPkg": "@intercom/intercom-react-native",
+    "examples": [
+      "https://github.com/intercom/intercom-react-native/tree/main/example"
+    ],
+    "images": [
+      "https://images.ctfassets.net/xny2w179f4ki/2zU4haC1CGGDqkVpi4ffac/efdf1e8b2f5729f0b07428178ff62b74/customers-help-product-1.webp?&q=90&w=2560", 
+      "https://images.ctfassets.net/xny2w179f4ki/7kCxx0mYf5S5p1oNqqGSo2/f5126ee7c940c243a3cb90424da4b646/customers-omni-product-1.webp?&q=90&w=2560"],
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expoGo": false,
+    "windows": false,
+    "macos": false,
+    "tvos": false,
+    "visionos": false,
+    "unmaintained": false,
+    "dev": false,
+    "template": false
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1739,7 +1739,9 @@
   {
     "githubUrl": "https://github.com/tinycreative/react-native-intercom",
     "ios": true,
-    "android": true
+    "android": true,
+    "unmaintained": true,
+    "alternatives": ["@intercom/intercom-react-native"]
   },
   {
     "githubUrl": "https://github.com/joshswan/react-native-globalize",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1737,11 +1737,6 @@
     "android": true
   },
   {
-    "githubUrl": "https://github.com/tinycreative/react-native-intercom",
-    "ios": true,
-    "android": true
-  },
-  {
     "githubUrl": "https://github.com/joshswan/react-native-globalize",
     "ios": true,
     "android": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -11910,15 +11910,6 @@
       "https://images.ctfassets.net/xny2w179f4ki/2zU4haC1CGGDqkVpi4ffac/efdf1e8b2f5729f0b07428178ff62b74/customers-help-product-1.webp?&q=90&w=2560", 
       "https://images.ctfassets.net/xny2w179f4ki/7kCxx0mYf5S5p1oNqqGSo2/f5126ee7c940c243a3cb90424da4b646/customers-omni-product-1.webp?&q=90&w=2560"],
     "ios": true,
-    "android": true,
-    "web": false,
-    "expoGo": false,
-    "windows": false,
-    "macos": false,
-    "tvos": false,
-    "visionos": false,
-    "unmaintained": false,
-    "dev": false,
-    "template": false
+    "android": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how
[Intercom](https://www.intercom.com) is a platform for support in mobile. This PR is to add their official bridge to the react native directory - it's maintained and working, I use it in my app; they have developed the correct Expo config plugin.  

As of New Architecture, I don't think they support it yet - I have'nt tried it, but I don't see in their release notes from the last past year anything related to supporting it. I intentionally let no boolean "New Architecture" to have the `untested` status displayed.  

# ✅ Checklist
- [x] Updated library in **`react-native-libraries.json`**

