### PR TITLE
chore: update status of react-native-camera-kit

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4391,7 +4391,9 @@
       "https://raw.githubusercontent.com/teslamotors/react-native-camera-kit/master/images/screenshot.jpg"
     ],
     "ios": true,
-    "android": true
+    "android": true,
+    "newArchitecture":false,
+    "newArchitectureNote": "PR open for new architecture support https://github.com/teslamotors/react-native-camera-kit/issues/537"
   },
   {
     "githubUrl": "https://github.com/BondGoat/react-native-native-video-player",
@@ -11906,7 +11908,7 @@
     "expoGo": true,
     "macos": true,
     "newArchitecture": true
-  }, 
+  },
   {
     "githubUrl": "https://github.com/intercom/intercom-react-native",
     "npmPkg": "@intercom/intercom-react-native",
@@ -11914,7 +11916,7 @@
       "https://github.com/intercom/intercom-react-native/tree/main/example"
     ],
     "images": [
-      "https://images.ctfassets.net/xny2w179f4ki/2zU4haC1CGGDqkVpi4ffac/efdf1e8b2f5729f0b07428178ff62b74/customers-help-product-1.webp?&q=90&w=2560", 
+      "https://images.ctfassets.net/xny2w179f4ki/2zU4haC1CGGDqkVpi4ffac/efdf1e8b2f5729f0b07428178ff62b74/customers-help-product-1.webp?&q=90&w=2560",
       "https://images.ctfassets.net/xny2w179f4ki/7kCxx0mYf5S5p1oNqqGSo2/f5126ee7c940c243a3cb90424da4b646/customers-omni-product-1.webp?&q=90&w=2560"],
     "ios": true,
     "android": true


### PR DESCRIPTION

# 📝 Why & how
As reported here -> https://github.com/reactwg/react-native-new-architecture/discussions/167#discussioncomment-9674242 

`react-native-camera-kit` does not support new architecture yet.
I have updated this info in the directory.


# ✅ Checklist
- [x] Updated library in **`react-native-libraries.json`**

