### PR TITLE
fix npm fetch throwing for packages with no downloads

### DIFF
--- a/scripts/fetch-npm-data.js
+++ b/scripts/fetch-npm-data.js
@@ -58,7 +58,7 @@ export const fetchNpmData = async (pkgData, attemptsCount = 0) => {
     const response = await fetch(url);
     const downloadData = await response.json();
 
-    if (!downloadData.downloads) {
+    if (!downloadData.package) {
       console.warn(
         `[NPM] ${npmPkg} doesn't exist on npm registry, add npmPkg to its entry or remove it!`
       );


### PR DESCRIPTION
# 📝 Why & how

Refs #1349

This case exposed that npm fetch will throw unexpectedly for packages with no downloads. 

Let's relay on `package` key existence instead, to avoid `0` being interpreted as falsy value.

# ✅ Checklist

- [x] Documented in this PR how you fixed or created the feature.
