### PR TITLE
Add react-native-get-device-locale

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12455,5 +12455,15 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/wneel/react-native-get-device-locale",
+    "npmPkg": "react-native-get-device-locale",
+    "examples": [
+      "https://github.com/wneel/react-native-get-device-locale",
+      "https://snack.expo.dev/@wawa2048/react-native-get-device-locale-demo"
+    ],
+    "ios": true,
+    "newArchitecture": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12458,7 +12458,6 @@
   },
   {
     "githubUrl": "https://github.com/wneel/react-native-get-device-locale",
-    "npmPkg": "react-native-get-device-locale",
     "examples": [
       "https://github.com/wneel/react-native-get-device-locale",
       "https://snack.expo.dev/@wawa2048/react-native-get-device-locale-demo"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
Adding the `react-native-get-device-locale` library to fetch the device locale (language and region) on and iOS for React Native apps with and without the new Architecture !


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added library to **`react-native-libraries.json`**
