### PR TITLE
Add NativeSass to React Native Directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12461,5 +12461,13 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/filipe-2/native-sass",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how
This PR adds the NativeSass library to React Native Directory, the library enables nesting, shared styles, and other features.

# ✅ Checklist
- [X] Added library to **`react-native-libraries.json`**