### PR TITLE
Mark lack of support for new arch on rive

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -11228,7 +11228,8 @@
     "githubUrl": "https://github.com/rive-app/rive-react-native",
     "examples": ["https://github.com/rive-app/rive-react-native/tree/main/example"],
     "android": true,
-    "ios": true
+    "ios": true,
+    "newArchitecture": false
   },
   {
     "githubUrl": "https://github.com/beaverfy/react-native-wear",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
Mark lack of support for new arch on rive


# ✅ Checklist

<!-- If you added a new library or updated the existing one -->
- [x] Updated library in **`react-native-libraries.json`**

Here is the clear evidence of lack of support:
https://github.com/rive-app/rive-react-native/issues/190
