### PR TITLE
Fix: Remove macOS support from `react-native-nitro-sqlite`

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12645,7 +12645,6 @@
     ],
     "ios": true,
     "android": true,
-    "macos": true,
     "newArchitecture": true
   }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

During my previous PR which adds `react-native-nitro-sqlite` i added `"macos": true` to NitroSQLite listing. This was added by accident, as of now the library doesn't have official macOS support.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
