### PR TITLE
Add tvOS & visionOS sections to Popular page

### DIFF
--- a/pages/popular.tsx
+++ b/pages/popular.tsx
@@ -6,11 +6,13 @@ import ContentContainer from '../components/ContentContainer';
 import ExploreSection from '../components/Explore/ExploreSection';
 import {
   PlatformAndroid,
+  PlatformExpo,
   PlatformIOS,
   PlatformMacOS,
+  PlatformTvOS,
+  PlatformVisionOS,
   PlatformWeb,
   PlatformWindows,
-  PlatformExpo,
   ReactLogo,
 } from '../components/Icons';
 import Navigation from '../components/Navigation';
@@ -62,6 +64,18 @@ const Popular = ({ data }) => {
           icon={PlatformMacOS}
           data={data}
           filter={lib => lib.macos === true}
+        />
+        <ExploreSection
+          title="tvOS"
+          icon={PlatformTvOS}
+          data={data}
+          filter={lib => lib.tvos === true}
+        />
+        <ExploreSection
+          title="VisionOS"
+          icon={PlatformVisionOS}
+          data={data}
+          filter={lib => lib.visionos === true}
         />
         <ExploreSection
           title="Web"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
Adding the remaining OOT Platforms, tvOS and visionOS, to the Popular page.

# ✅ Checklist
- [x] When running the site locally, the two new platforms are displayed.

## To test:
```shell
gh repo clone cgoldsby/directory
git checkout feature/popular-page-update
yarn && yarn start
```
