### PR TITLE
Fix visionOS capitalization on the Profile page

### DIFF
--- a/pages/popular.tsx
+++ b/pages/popular.tsx
@@ -72,7 +72,7 @@ const Popular = ({ data }) => {
           filter={lib => lib.tvos === true}
         />
         <ExploreSection
-          title="VisionOS"
+          title="visionOS"
           icon={PlatformVisionOS}
           data={data}
           filter={lib => lib.visionos === true}


### PR DESCRIPTION
# 📝 Why & how
According to Apple's developer guidelines, "visionOS" should not be capitalized; it always starts with a lowercase "v", even at the beginning of a sentence.

I apologize; it was I who initially capitalized visionOS. Today, I learned that is not  correct. 🙇 

Reference:
[Submit your apps to the App Store for Apple Vision Pro / Describe your app
](https://developer.apple.com/visionos/submit/#:~:text=visionOS%3A%20visionOS%20begins%20with%20a,or%20mixed%20reality%20(MR))

> visionOS: visionOS begins with a lowercase v, even when it’s the first word in a sentence.

# ✅ Checklist
- [x] visionOS capitalization is correct on the Profile page
## To test:
```shell
gh repo clone react-native-community-directory
git checkout visionOSCapitalizationFix
yarn && yarn start
```
