### PR TITLE
flag react-native-maps as new arch incompatible

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -578,7 +578,7 @@
       "https://snack.expo.dev/H1zOFxnN-"
     ],
     "goldstar": true,
-    "newArchitecture": true
+    "newArchitecture": false
   },
   {
     "githubUrl": "https://github.com/bramus/react-native-maps-directions",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

As per [this comment](https://github.com/react-native-maps/react-native-maps/issues/5206#issuecomment-2513067290) of react-native-maps' maintainer, let's indicate that the library is new arch incompatible. While it CAN run with the interop layer, it has a plethora of issues that need to be resolved by properly migrating the library and its views to Fabric & new arch. Highlighting this library as new arch compatible (even more so that its highlighted as "recommended library") will only encourage usage of the library with new arch, putting even more strain on the `react-native-maps` maintainers while they are in the middle of migrating - just check the issue board on that repo, it's flooded with new arch issues. 

With that said, it might be worth to indicate incompatibility with new arch in react native directory, and only reenable it once the compatibility has been widely confirmed by the community.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [X] Updated library in **`react-native-libraries.json`**
