### PR TITLE
Update expo-background-fetch: supports newArch

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -2649,7 +2649,7 @@
     "ios": true,
     "android": true,
     "expoGo": true,
-    "newArchitecture": false
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/expo/expo/tree/main/packages/expo-barcode-scanner",
@@ -13062,14 +13062,15 @@
   },
   {
     "githubUrl": "https://github.com/fishjam-cloud/mobile-client-sdk/tree/main/packages/react-native-client",
-    "examples": ["https://github.com/fishjam-cloud/mobile-client-sdk/tree/main/examples/fishjam-chat"],
+    "examples": [
+      "https://github.com/fishjam-cloud/mobile-client-sdk/tree/main/examples/fishjam-chat"
+    ],
     "npmPkg": "@fishjam-cloud/react-native-client",
     "images": [
       "https://raw.githubusercontent.com/fishjam-cloud/mobile-client-sdk/main/.github/images/fishjam-card.png"
     ],
     "ios": true,
     "android": true,
-    "expoGo": false,
     "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Updated newArchitecture field to true:

```diff
{
    "githubUrl": "https://github.com/expo/expo/tree/main/packages/expo-background-fetch",
    "ios": true,
    "android": true,
    "expoGo": true,
-    "newArchitecture": false
+    "newArchitecture": true
  },
```

# ✅ Checklist

- [X] Updated library in **`react-native-libraries.json`**
