### PR TITLE
chore: react-native-volume-manager newArch support

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -8821,7 +8821,7 @@
     ],
     "ios": true,
     "android": true,
-    "expoGo": true
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/aws/amazon-ivs-react-native-player",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

react-native-volume-manager supports the new architecture now. I've added the flag and removed Expo Go, because it doesn't work with Expo Go.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
