### PR TITLE
Update newArchitecture value for react-native-a11y-slider and react-fancy-qrcode

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -9575,7 +9575,8 @@
       "https://raw.githubusercontent.com/jgillick/react-native-a11y-slider/HEAD/examples.png"
     ],
     "ios": true,
-    "android": true
+    "android": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/jgillick/react-fancy-qrcode",
@@ -9590,7 +9591,8 @@
     ],
     "ios": true,
     "android": true,
-    "web": true
+    "web": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/mutualmobile/react-native-barricade",


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
This sets the `newArchitecture` value for two libraries that I maintain: [react-native-a11y-slider](https://github.com/jgillick/react-native-a11y-slider) and [react-fancy-qrcode](https://github.com/jgillick/react-fancy-qrcode)


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [X] Updated library in **`react-native-libraries.json`**
