### PR TITLE
Update react-native-bottom-tabs metadata

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12215,11 +12215,12 @@
     "expoGo": true
   },
   {
-    "githubUrl": "https://github.com/okwasniewski/react-native-bottom-tabs",
-    "examples": ["https://github.com/okwasniewski/react-native-bottom-tabs/tree/main/example"],
+    "githubUrl": "https://github.com/callstackincubator/react-native-bottom-tabs",
+    "examples": ["https://github.com/callstackincubator/react-native-bottom-tabs/tree/main/example"],
     "ios": true,
     "android": true,
-    "visionos": true
+    "visionos": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/AlirezaHadjar/react-native-fast-confetti",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
I have updated the `react-native-bottom-tabs` library.

The library does support the new architecture, see:
https://github.com/callstackincubator/react-native-bottom-tabs/pull/64
https://github.com/callstackincubator/react-native-bottom-tabs/pull/79
I have also tested this myself.

To conclude with, I have updated the GitHub URL since the library was moved to the `callstackincubator` organization.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Updated library in **`react-native-libraries.json`**
