### PR TITLE
Change repo URL of react-native-deck-swiper

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1370,11 +1370,15 @@
     "expoGo": true
   },
   {
-    "githubUrl": "https://github.com/alexbrillant/react-native-deck-swiper",
+    "githubUrl": "https://github.com/webraptor/react-native-deck-swiper",
     "ios": true,
     "android": true,
     "expoGo": true,
-    "examples": ["https://snack.expo.dev/rJBRhOLU-"]
+    "examples": ["https://github.com/webraptor/react-native-deck-swiper/tree/master/example"],
+    "images": [
+      "https://github.com/webraptor/react-native-deck-swiper/raw/master/animation.gif",
+      "https://github.com/webraptor/react-native-deck-swiper/blob/master/animation2.gif"
+    ]
   },
   {
     "githubUrl": "https://github.com/d-a-n/react-native-webbrowser",


### PR DESCRIPTION
# 📝 Why & how
The GitHub link previously provided points to a repo that is no longer maintained. I updated the link to the fork URL that is listed on the official NPM registry: https://www.npmjs.com/package/react-native-deck-swiper

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [X] Updated library in **`react-native-libraries.json`**

