### PR TITLE
Add font-awesome free packages

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -13388,7 +13388,7 @@
     "newArchitecture": true
   },
   {
-    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/%40fortawesome/fontawesome-svg-core",
+    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/@fortawesome/fontawesome-svg-core",
     "npmPkg": "@fortawesome/fontawesome-svg-core",
     "ios": true,
     "android": true,
@@ -13396,7 +13396,7 @@
     "expo": true
   },
   {
-    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/%40fortawesome/free-brands-svg-icons",
+    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/@fortawesome/free-brands-svg-icons",
     "npmPkg": "@fortawesome/free-brands-svg-icons",
     "ios": true,
     "android": true,
@@ -13404,7 +13404,7 @@
     "expo": true
   },
   {
-    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/%40fortawesome/free-regular-svg-icons",
+    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/@fortawesome/free-regular-svg-icons",
     "npmPkg": "@fortawesome/free-regular-svg-icons",
     "ios": true,
     "android": true,
@@ -13412,7 +13412,7 @@
     "expo": true
   },
   {
-    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/%40fortawesome/free-solid-svg-icons",
+    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/@fortawesome/free-solid-svg-icons",
     "npmPkg": "@fortawesome/free-solid-svg-icons",
     "ios": true,
     "android": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -13386,5 +13386,37 @@
     "web": true,
     "expo": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/%40fortawesome/fontawesome-svg-core",
+    "npmPkg": "@fortawesome/fontawesome-svg-core",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/%40fortawesome/free-brands-svg-icons",
+    "npmPkg": "@fortawesome/free-brands-svg-icons",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/%40fortawesome/free-regular-svg-icons",
+    "npmPkg": "@fortawesome/free-regular-svg-icons",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expo": true
+  },
+  {
+    "githubUrl": "https://github.com/FortAwesome/Font-Awesome/tree/6.x/js-packages/%40fortawesome/free-solid-svg-icons",
+    "npmPkg": "@fortawesome/free-solid-svg-icons",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expo": true
   }
 ]


### PR DESCRIPTION
There also exist pro-packages, but they are not on github and so cannot be added to this list.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
These libraries are often used with [`@fortawesome/react-native-fontawesome`](https://github.com/FortAwesome/react-native-fontawesome). They work with the new architecture, [following their documentation ](https://docs.fontawesome.com/web/use-with/react-native), but I don't know if the automatic architecture detection will fail or not. May need to be changed to indicate that it works via `newArchitecture: true`.

# ✅ Checklist
- [x] Added library to **`react-native-libraries.json`**
