### PR TITLE
Set "newArchitecture": false for stripe-react-native

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6807,7 +6807,8 @@
     "examples": ["https://github.com/stripe/stripe-react-native/tree/master/example"],
     "ios": true,
     "android": true,
-    "expoGo": true
+    "expoGo": true,
+    "newArchitecture": false
   },
   {
     "githubUrl": "https://github.com/swaplet/react-native-swipe-cards-deck",


### PR DESCRIPTION
We've received some issues related to New Architecture (e.g., https://github.com/stripe/stripe-react-native/issues/1774 and https://github.com/stripe/stripe-react-native/issues/1732). We want to clarify that this library does not support the New Architecture until it has been adequately supported and tested.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
