### PR TITLE
Mark VisionCamera as new-arch compatible

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3337,7 +3337,8 @@
     "ios": true,
     "android": true,
     "windows": true,
-    "unmaintained": true
+    "unmaintained": true,
+    "alternatives": ["react-native-vision-camera"]
   },
   {
     "githubUrl": "https://github.com/seniv/react-native-notifier",
@@ -4416,7 +4417,8 @@
     "ios": true,
     "android": true,
     "newArchitecture": false,
-    "newArchitectureNote": "PR open for new architecture support https://github.com/teslamotors/react-native-camera-kit/issues/537"
+    "newArchitectureNote": "PR open for new architecture support https://github.com/teslamotors/react-native-camera-kit/issues/537",
+    "alternatives": ["react-native-vision-camera"]
   },
   {
     "githubUrl": "https://github.com/BondGoat/react-native-native-video-player",
@@ -6421,7 +6423,9 @@
       "https://raw.githubusercontent.com/mrousavy/react-native-vision-camera/main/docs/static/img/demo.gif"
     ],
     "ios": true,
-    "android": true
+    "android": true,
+    "newArchitecture": true,
+    "newArchitectureNote": "Currently supported through the compatibility layer for legacy view components."
   },
   {
     "githubUrl": "https://github.com/dabakovich/react-native-controlled-mentions",

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4417,8 +4417,7 @@
     "ios": true,
     "android": true,
     "newArchitecture": false,
-    "newArchitectureNote": "PR open for new architecture support https://github.com/teslamotors/react-native-camera-kit/issues/537",
-    "alternatives": ["react-native-vision-camera"]
+    "newArchitectureNote": "PR open for new architecture support https://github.com/teslamotors/react-native-camera-kit/issues/537"
   },
   {
     "githubUrl": "https://github.com/BondGoat/react-native-native-video-player",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

Marks VisionCamera as new-arch compatible, although it is currently just using the interop layer.
But it works :)

Also, I added VisionCamera to the list of alternatives for react-native-camera (because it's unmaintained) and react-native-camera-kit (because it doesn't support new arch)

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
