### PR TITLE
temporarily disable GitHub images scraping

### DIFF
--- a/scripts/build-and-score-data.js
+++ b/scripts/build-and-score-data.js
@@ -24,7 +24,7 @@ const DATASET = USE_DEBUG_REPOS ? debugGithubRepos : githubRepos;
 const LOAD_GITHUB_RESULTS_FROM_DISK = false;
 
 // If script should try to scrape images from GitHub repositories.
-const SCRAPE_GH_IMAGES = true;
+const SCRAPE_GH_IMAGES = false;
 const DATA_PATH = path.resolve('assets', 'data.json');
 const GITHUB_RESULTS_PATH = path.join('scripts', 'raw-github-results.json');
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

Looks like GitHub images scraping causes deployment to run out of declared max time. 

For now, to unblock new deployment, we can disable additional images scraping.

# ✅ Checklist
- [x] Documented in this PR how you fixed or created the feature.
