### PR TITLE
disable fetching weekly npm data due to API limits

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -6,8 +6,8 @@ on:
     paths-ignore:
       - 'react-native-libraries.json'
   schedule:
-    # Run every 2 hours - https://crontab.guru/#0_*/2_*_*_*
-    - cron: '0 */2 * * *'
+    # Run every 3 hours - https://crontab.guru/#0_*/3_*_*_*
+    - cron: '0 */3 * * *'
 
 jobs:
   build:

--- a/scripts/build-and-score-data.js
+++ b/scripts/build-and-score-data.js
@@ -83,13 +83,14 @@ const buildAndScoreData = async () => {
   let bulkList = [];
 
   // https://github.com/npm/registry/blob/main/docs/download-counts.md#limits
-  const CHUNK_SIZE = 80;
+  const CHUNK_SIZE = 25;
 
   // Fetch scoped packages data
   data = await Promise.all(
-    data.map(project => {
+    data.map(async project => {
       if (!project.template) {
         if (project.npmPkg.startsWith('@')) {
+          await sleep(Math.max(Math.random() * 2500));
           return fetchNpmData(project);
         } else {
           bulkList.push(project.npmPkg);
@@ -114,21 +115,21 @@ const buildAndScoreData = async () => {
     )
   ).flat();
 
-  const downloadsListWeek = (
-    await Promise.all(
-      bulkList.map(async (chunk, index) => {
-        await sleep(Math.max(2500 * index, 15000));
-        return await fetchNpmDataBulk(chunk, 'week');
-      })
-    )
-  ).flat();
+  // const downloadsListWeek = (
+  //   await Promise.all(
+  //     bulkList.map(async (chunk, index) => {
+  //       await sleep(Math.max(2500 * index, 15000));
+  //       return await fetchNpmDataBulk(chunk, 'week');
+  //     })
+  //   )
+  // ).flat();
 
   // Fill npm data from bulk queries
   data = data.map(project => ({
     ...project,
     npm: {
       ...(downloadsList.find(entry => entry.name === project.npmPkg)?.npm ?? {}),
-      ...(downloadsListWeek.find(entry => entry.name === project.npmPkg)?.npm ?? {}),
+      // ...(downloadsListWeek.find(entry => entry.name === project.npmPkg)?.npm ?? {}),
     },
   }));
 
@@ -136,8 +137,8 @@ const buildAndScoreData = async () => {
   data = data.map(project => {
     try {
       return calculateDirectoryScore(project);
-    } catch (e) {
-      console.error(`Failed to calculate score for ${project.github.name}`, e.message);
+    } catch (error) {
+      console.error(`Failed to calculate score for ${project.github.name}`, error.message);
     }
   });
 
@@ -145,8 +146,8 @@ const buildAndScoreData = async () => {
   data = data.map(project => {
     try {
       return calculatePopularityScore(project);
-    } catch (e) {
-      console.error(`Failed to calculate popularity for ${project.github.name}`, e.message);
+    } catch (error) {
+      console.error(`Failed to calculate popularity for ${project.github.name}`, error.message);
       console.error(project.githubUrl);
     }
   });

--- a/scripts/calculate-score.js
+++ b/scripts/calculate-score.js
@@ -116,12 +116,12 @@ const WEEK_IN_MS = 6048e5;
 
 export const calculatePopularityScore = data => {
   const {
-    npm: { downloads, weekDownloads },
+    npm: { downloads },
     github,
     unmaintained,
   } = data;
 
-  if (!downloads || !weekDownloads) {
+  if (!downloads) {
     return {
       ...data,
       popularity: -100,
@@ -130,7 +130,9 @@ export const calculatePopularityScore = data => {
 
   const { createdAt, stars } = github.stats;
 
-  const popularityGain = (weekDownloads - Math.floor(downloads / 4.5)) / downloads;
+  // Figure out better way to determine popularity gain, since with amount of libraries
+  // we list, we are hitting npm API limits when fetching twice, for each entry
+  const popularityGain = (Math.floor(downloads / 4) - Math.floor(downloads / 4.5)) / downloads;
 
   const downloadsPenalty = downloads < MIN_MONTHLY_DOWNLOADS ? 0.25 : 0;
   const starsPenalty = stars < MIN_GITHUB_STARS ? 0.1 : 0;

--- a/scripts/fetch-npm-data.js
+++ b/scripts/fetch-npm-data.js
@@ -2,7 +2,7 @@ import fetch from 'cross-fetch';
 
 import { sleep, REQUEST_SLEEP } from './helpers.js';
 
-const ATTEMPTS_LIMIT = 3;
+const ATTEMPTS_LIMIT = 2;
 
 const urlForPackage = (npmPkg, period = 'month') => {
   return `https://api.npmjs.org/downloads/point/last-${period}/${npmPkg}`;
@@ -67,15 +67,15 @@ export const fetchNpmData = async (pkgData, attemptsCount = 0) => {
       return { ...pkgData, npm: null };
     }
 
-    const weekUrl = urlForPackage(npmPkg, 'week');
-    const weekResponse = await fetch(weekUrl);
-    const weekDownloadData = await weekResponse.json();
+    // const weekUrl = urlForPackage(npmPkg, 'week');
+    // const weekResponse = await fetch(weekUrl);
+    // const weekDownloadData = await weekResponse.json();
 
     return {
       ...pkgData,
       npm: {
         downloads: downloadData.downloads,
-        weekDownloads: weekDownloadData.downloads,
+        // weekDownloads: weekDownloadData.downloads,
         start: downloadData.start,
         end: downloadData.end,
         period: 'month',

--- a/scripts/fetch-readme-images.js
+++ b/scripts/fetch-readme-images.js
@@ -46,7 +46,7 @@ const fetchReadmeImages = async (data, attemptsCount = 0) => {
    * @DEV
    * if images been set, or max attempt count has been reached, we skip scraping images
    */
-  if (data.images || attemptsCount > 5) {
+  if (data.images || attemptsCount > 3) {
     return data;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

Recently, the amount of rejected NPM API calls is steadily increasing, affecting the libraries scoring.

Let's attempt reducing those call in half, by skipping fetching an additional weekly download data. Those stats are not crucial, but help us generate popularity score, adding a bit more confidence in end value. 

# ✅ Checklist

- [x] Documented in this PR how you fixed or created the feature.
