### PR TITLE
add @sellpy/react-native-scroll-anchor

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -13676,5 +13676,14 @@
     "android": true,
     "expoGo": false,
     "web": false
+  },
+  {
+    "githubUrl": "https://github.com/sellpy/react-native-scroll-anchor",
+    "examples": ["https://github.com/sellpy/react-native-scroll-anchor/tree/main/example"],
+    "npmPkg": "@sellpy/react-native-scroll-anchor",
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "web": false
   }
 ]


### PR DESCRIPTION
# 📝 Why & how
This adds the package `@sellpy/react-native-scroll-anchor`. 
Library is used by hundres of thousands of users every week by primarily this app: https://apps.apple.com/se/app/sellpy-shop-second-hand/id1594599102


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added `@sellpy/react-native-scroll-anchor` library to **`react-native-libraries.json`**