### PR TITLE
Add expo-googlenearby-connection

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -13862,5 +13862,15 @@
     "expoGo": true,
     "dev": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/fabrizioiacobucci/expo-googlenearby-connection",
+    "npmPkg": "expo-googlenearby-connection",
+    "examples": [
+      "https://github.com/fabrizioiacobucci/expo-googlenearby-connection/tree/main/nearby-example"
+    ],
+    "android": true,
+    "unmaintained": false,
+    "newArchitecture": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -13865,7 +13865,6 @@
   },
   {
     "githubUrl": "https://github.com/fabrizioiacobucci/expo-googlenearby-connection",
-    "npmPkg": "expo-googlenearby-connection",
     "examples": [
       "https://github.com/fabrizioiacobucci/expo-googlenearby-connection/tree/main/nearby-example"
     ],

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -13870,7 +13870,6 @@
       "https://github.com/fabrizioiacobucci/expo-googlenearby-connection/tree/main/nearby-example"
     ],
     "android": true,
-    "unmaintained": false,
     "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
Add new Expo module `expo-googlenearby-connection` to use Google Nearby Connection SDK which is a peer-to-peer networking API that allows apps to easily discover, connect to, and exchange data with nearby devices in real-time, regardless of network connectivity.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [X] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
