### PR TITLE
Add react-native-purchases-ui

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14019,7 +14019,7 @@
     "newArchitecture": true
   },
   {
-    "githubUrl": "https://github.com/RevenueCat/react-native-purchases",
+    "githubUrl": "https://github.com/RevenueCat/react-native-purchases/tree/main/react-native-purchases-ui",
     "npmPkg": "react-native-purchases-ui",
     "examples": [
       "https://github.com/RevenueCat/react-native-purchases/tree/main/examples/MagicWeather"

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14017,5 +14017,15 @@
     "web": true,
     "expoGo": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/RevenueCat/react-native-purchases",
+    "npmPkg": "react-native-purchases-ui",
+    "examples": [
+      "https://github.com/RevenueCat/react-native-purchases/tree/main/examples/MagicWeather"
+    ],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how
Adds `react-native-purchases-ui` package. 
RevenueCat ships the `react-native-purchases` and `react-native-purchases-ui` packages separately. 
The `react-native-purchases-ui` package hadn't been registered before. 

~**Note:** I added this package as a separate entry. There are notes [about monorepo handling in the readme](https://github.com/react-native-community/directory/?tab=readme-ov-file#new-library-entry-template) but I wasn't entirely sure how to apply them, so let me know if this isn't right.~

~My interpretation is having a separate listing for each package with the same GitHub URL but different NPM package.~

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [X] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
