### PR TITLE
Update deployment instructions in README to use bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,5 @@ https://reactnative.directory/api/libraries
 
 ```sh
 # once environment variables are configured, install Vercel and deploy
-npm i -g vercel
-vercel
+bunx vercel
 ```


### PR DESCRIPTION
# 📝 Why & how
This PR updates the deployment instructions in the README to use `bunx vercel` instead of the npm-based global installation approach. This makes the documentation consistent with:
1. The GitHub Actions workflow for production deployments, which already uses bunx vercel
2. The project's migration to Bun as the primary JavaScript runtime (required version 1.2+)

The change is simple but important for consistency - it replaces:
```
npm i -g vercel
vercel
```
With:
```
bunx vercel
```

# ✅ Checklist
- [x] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
