### PR TITLE
Add HelpKit Help Center React Native SDK

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14096,5 +14096,14 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/HelpkitHQ/helpkit-help-center-react-native",
+    "npmPkg": "@helpkit/helpkit-help-center-react-native",
+    "examples": ["https://github.com/HelpkitHQ/helpkit-help-center-react-native/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how
Adding new HelpKit React Native package for easily embedding a Notion-powered help center inside React Native mobile apps


# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
