### PR TITLE
Update the Navigation router to reference just the one navigation package

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12336,27 +12336,14 @@
     "newArchitecture": true
   },
   {
-    "githubUrl": "https://github.com/grahammendick/navigation/tree/master/build/npm/navigation",
-    "ios": true,
-    "android": true,
-    "web": true,
-    "newArchitecture": true
-  },
-  {
-    "githubUrl": "https://github.com/grahammendick/navigation/tree/master/build/npm/navigation-react",
-    "examples": ["https://github.com/grahammendick/navigation/tree/master/NavigationReact/sample"],
-    "ios": true,
-    "android": true,
-    "web": true,
-    "newArchitecture": true
-  },
-  {
-    "githubUrl": "https://github.com/grahammendick/navigation/tree/master/build/npm/navigation-react-native",
+    "githubUrl": "https://github.com/grahammendick/navigation",
+    "npmPkg": "https://www.npmjs.com/package/navigation",
     "examples": [
-      "https://github.com/grahammendick/navigation/tree/master/NavigationReactNative/sample"
+      "https://github.com/grahammendick/navigation/tree/master/NavigationReactNative/sample/fabric"
     ],
     "ios": true,
     "android": true,
+    "web": true,
     "newArchitecture": true
   },
   {


### PR DESCRIPTION
# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

[The Navigation router was added to the react native directory](https://github.com/react-native-community/directory/pull/1328) as 3 separate packages - navigation, navigation-react and navigation-react-native. But, after [chatting with @Simek on twitter](https://x.com/Simek/status/1849093053304201415) we decided it makes more sense to just add the navigation package and remove navigation-react and navigation-react-native. He suggested some changes to the [navigation npm README](https://www.npmjs.com/package/navigation) which I've also now done.

![image](https://github.com/user-attachments/assets/af951246-9804-45ee-9179-394e1c0b35d7)


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
