### PR TITLE
fix(docs): calculate-score.js -> .ts broken link

### DIFF
--- a/pages/scoring.tsx
+++ b/pages/scoring.tsx
@@ -78,7 +78,7 @@ const Scoring = () => {
           lose value by exhibiting &quot;bad behavior criteria&quot;. These criteria and their
           corresponding weights are detailed below. You can see the code this directory uses to
           create Directory Scores{' '}
-          <A href="https://github.com/react-native-directory/website/blob/main/scripts/calculate-score.js">
+          <A href="https://github.com/react-native-directory/website/blob/main/scripts/calculate-score.ts">
             here
           </A>
           .
@@ -132,7 +132,7 @@ const Scoring = () => {
           criterion and can lose score by exhibiting one of bad criteria. These criteria and their
           corresponding weights are detailed below. You can see the code this directory uses to
           create Trending Scores{' '}
-          <A href="https://github.com/react-native-directory/website/blob/main/scripts/calculate-score.js">
+          <A href="https://github.com/react-native-directory/website/blob/main/scripts/calculate-score.ts">
             here
           </A>
           .


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
The links on the [scoring](https://reactnative.directory/scoring?utm_source=chatgpt.com) page are broken, they are linking to the old .js file. This change updates those links to be referencing the .ts file.