### PR TITLE
move "update at" information to save some vertical space, other tweaks

### DIFF
--- a/common/styleguide.tsx
+++ b/common/styleguide.tsx
@@ -168,7 +168,7 @@ export const A = ({ href, target = '_blank', children, style, hoverStyle, ...res
 const getLinkStyles = (isDark: boolean) => ({
   color: isDark ? colors.white : colors.black,
   backgroundColor: isDark ? darkColors.powder : colors.powder,
-  textDecorationColor: isDark ? darkColors.pewter : colors.pewter,
+  textDecorationColor: isDark ? colors.gray5 : colors.pewter,
   textDecorationLine: 'underline',
   fontFamily: 'inherit',
 });
@@ -176,7 +176,7 @@ const getLinkStyles = (isDark: boolean) => ({
 const getLinkHoverStyles = (isDark: boolean) => ({
   backgroundColor: isDark ? colors.primaryDark : colors.sky,
   color: isDark ? darkColors.dark : colors.black,
-  textDecorationColor: isDark ? darkColors.powder : colors.black,
+  textDecorationColor: isDark ? darkColors.powder : colors.gray4,
 });
 
 export const HoverEffect = ({ children }) => {

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -4,21 +4,9 @@ import { StyleSheet, View } from 'react-native';
 import { colors, A, P, Caption, darkColors } from '~/common/styleguide';
 import CustomAppearanceContext from '~/context/CustomAppearanceContext';
 import { Library as LibraryType } from '~/types';
-import { getTimeSinceToday } from '~/util/datetime';
 
 import { DirectoryScore } from './DirectoryScore';
-import {
-  Calendar,
-  Star,
-  Download,
-  Eye,
-  Issue,
-  Web,
-  License,
-  Fork,
-  Code,
-  TypeScript,
-} from '../Icons';
+import { Star, Download, Eye, Issue, Web, License, Fork, Code, TypeScript } from '../Icons';
 
 type Props = {
   library: LibraryType;
@@ -38,15 +26,6 @@ function generateData({ github, score, npm, npmPkg }: LibraryType, isDark: boole
           style={{ ...styles.link, ...styles.mutedLink }}
           hoverStyle={isDark && { color: colors.primaryDark }}>
           Directory Score
-        </A>
-      ),
-    },
-    {
-      id: 'calendar',
-      icon: <Calendar fill={iconColor} />,
-      content: (
-        <A href={`${github.urls.repo}/commits`} style={styles.link}>
-          Updated {getTimeSinceToday(github.stats.pushedAt)}
         </A>
       ),
     },

--- a/components/Library/TrendingMark.tsx
+++ b/components/Library/TrendingMark.tsx
@@ -45,7 +45,7 @@ const TrendingMark = ({ library, style, markOnly = false }: Props) => {
   return markOnly ? (
     <View style={[styles.container, style]}>{content}</View>
   ) : (
-    <A href="/scoring" style={[styles.container, styles.scoringLink, style]}>
+    <A href="/scoring" style={[styles.scoringLink, style]}>
       {content}
     </A>
   );

--- a/components/Library/UnmaintainedLabel.tsx
+++ b/components/Library/UnmaintainedLabel.tsx
@@ -70,7 +70,7 @@ const styles = StyleSheet.create({
   unmaintainedTextContainer: {
     alignItems: 'flex-start',
     marginLeft: -20,
-    marginBottom: 12,
+    marginBottom: 8,
     paddingLeft: 20,
     paddingRight: 12,
     paddingVertical: 6,

--- a/components/Library/UpdateAtView.tsx
+++ b/components/Library/UpdateAtView.tsx
@@ -27,7 +27,7 @@ export default function UpdatedAtView({ library }: Props) {
       <Tooltip
         sideOffset={2}
         trigger={
-          <View style={{ cursor: 'pointer' }} aria-label="Last updated">
+          <View style={{ cursor: 'pointer' }} aria-label="Last update (based on git activity)">
             <Calendar
               fill={library.unmaintained ? unmaintainedIconColor : iconColor}
               width={14}
@@ -35,7 +35,7 @@ export default function UpdatedAtView({ library }: Props) {
             />
           </View>
         }>
-        Last updated
+        Last update (based on git activity)
       </Tooltip>
       <A
         href={`${library.github.urls.repo}/commits`}

--- a/components/Library/UpdateAtView.tsx
+++ b/components/Library/UpdateAtView.tsx
@@ -1,0 +1,73 @@
+import { useContext } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { A, colors, darkColors } from '~/common/styleguide';
+import CustomAppearanceContext from '~/context/CustomAppearanceContext';
+import { Library as LibraryType } from '~/types';
+import { getTimeSinceToday } from '~/util/datetime';
+
+import { Calendar } from '../Icons';
+
+type Props = {
+  library: LibraryType;
+};
+
+export default function UpdatedAtView({ library }: Props) {
+  const { isDark } = useContext(CustomAppearanceContext);
+
+  const iconColor = isDark ? darkColors.pewter : colors.secondary;
+  const textColor = isDark ? darkColors.secondary : colors.gray5;
+  const decorationColor = isDark ? colors.gray5 : colors.gray3;
+  const unmaintainedIconColor = isDark ? darkColors.warning : colors.warningDark;
+  const unmaintainedTextColor = isDark ? darkColors.warning : colors.warningDark;
+
+  return (
+    <View style={styles.updatedAtContainer}>
+      <Calendar
+        fill={library.unmaintained ? unmaintainedIconColor : iconColor}
+        width={14}
+        height={16}
+      />
+      <A
+        href={`${library.github.urls.repo}/commits`}
+        style={[
+          styles.link,
+          {
+            color: library.unmaintained ? unmaintainedTextColor : textColor,
+            textDecorationColor: decorationColor,
+          },
+        ]}
+        hoverStyle={[
+          {
+            color: library.unmaintained
+              ? unmaintainedTextColor
+              : isDark
+                ? colors.primaryDark
+                : textColor,
+            textDecorationColor: library.unmaintained
+              ? unmaintainedTextColor
+              : isDark
+                ? colors.gray6
+                : colors.gray4,
+          },
+        ]}>
+        Updated {getTimeSinceToday(library.github.stats.pushedAt)}
+      </A>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  updatedAtContainer: {
+    gap: 8,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+  },
+  link: {
+    fontSize: 13,
+    fontWeight: 300,
+    backgroundColor: 'transparent',
+    textDecorationColor: 'transparent',
+  },
+});

--- a/components/Library/UpdateAtView.tsx
+++ b/components/Library/UpdateAtView.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { A, colors, darkColors } from '~/common/styleguide';
+import Tooltip from '~/components/Tooltip';
 import CustomAppearanceContext from '~/context/CustomAppearanceContext';
 import { Library as LibraryType } from '~/types';
 import { getTimeSinceToday } from '~/util/datetime';
@@ -23,11 +24,19 @@ export default function UpdatedAtView({ library }: Props) {
 
   return (
     <View style={styles.updatedAtContainer}>
-      <Calendar
-        fill={library.unmaintained ? unmaintainedIconColor : iconColor}
-        width={14}
-        height={16}
-      />
+      <Tooltip
+        sideOffset={2}
+        trigger={
+          <View style={{ cursor: 'pointer' }} aria-label="Last updated">
+            <Calendar
+              fill={library.unmaintained ? unmaintainedIconColor : iconColor}
+              width={14}
+              height={16}
+            />
+          </View>
+        }>
+        Last updated
+      </Tooltip>
       <A
         href={`${library.github.urls.repo}/commits`}
         style={[
@@ -51,7 +60,7 @@ export default function UpdatedAtView({ library }: Props) {
                 : colors.gray4,
           },
         ]}>
-        Updated {getTimeSinceToday(library.github.stats.pushedAt)}
+        {getTimeSinceToday(library.github.stats.pushedAt)}
       </A>
     </View>
   );
@@ -62,7 +71,6 @@ const styles = StyleSheet.create({
     gap: 8,
     flexDirection: 'row',
     alignItems: 'flex-start',
-    justifyContent: 'space-between',
   },
   link: {
     fontSize: 13,

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -4,6 +4,7 @@ import { Linkify } from 'react-easy-linkify';
 import { Platform, StyleSheet, View } from 'react-native';
 
 import { colors, useLayout, A, darkColors, Headline } from '~/common/styleguide';
+import UpdatedAtView from '~/components/Library/UpdateAtView';
 import CustomAppearanceContext from '~/context/CustomAppearanceContext';
 import { Library as LibraryType } from '~/types';
 
@@ -46,25 +47,28 @@ const Library = ({ library, skipMetadata, showTrendingMark }: Props) => {
         library.unmaintained && styles.unmaintained,
       ]}>
       <View style={styles.columnOne}>
-        {library.unmaintained && <UnmaintainedLabel alternatives={library.alternatives} />}
-        {showTrendingMark && library.popularity && (
-          <Tooltip
-            sideOffset={8}
-            trigger={
-              <View style={styles.trendingMarkContainer}>
-                <TrendingMark library={library} />
-              </View>
-            }>
-            Trending Score is based on the last week to last month download rate.
-          </Tooltip>
+        {library.unmaintained && (
+          <View style={[styles.updatedAtContainer, styles.trendingMarkContainer]}>
+            <UnmaintainedLabel alternatives={library.alternatives} />
+            <UpdatedAtView library={library} />
+          </View>
         )}
-        <View style={isSmallScreen ? styles.containerColumn : styles.displayHorizontal}>
+        {showTrendingMark && library.popularity && (
+          <View style={[styles.updatedAtContainer, { marginBottom: 4 }]}>
+            <Tooltip sideOffset={8} trigger={<TrendingMark library={library} />}>
+              Trending Score is based on the last week to last month download rate.
+            </Tooltip>
+            {!library.unmaintained && <UpdatedAtView library={library} />}
+          </View>
+        )}
+        <View style={isSmallScreen ? styles.containerColumn : styles.updatedAtContainer}>
           <A
             href={library.githubUrl || github.urls.repo}
             style={styles.name}
             hoverStyle={{ color: isDark ? colors.gray3 : colors.gray5 }}>
             {libName}
           </A>
+          {!showTrendingMark && !library.unmaintained && <UpdatedAtView library={library} />}
         </View>
         <View style={styles.verticalMargin}>
           <CompatibilityTags library={library} />
@@ -195,7 +199,7 @@ const styles = StyleSheet.create({
   },
   imagesContainer: {
     flexWrap: 'wrap',
-    marginTop: 12,
+    marginTop: 8,
   },
   secondaryStats: {
     marginTop: 6,
@@ -240,7 +244,19 @@ const styles = StyleSheet.create({
     opacity: 0.88,
   },
   trendingMarkContainer: {
-    alignSelf: 'flex-start',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  link: {
+    fontSize: 13,
+    fontWeight: 300,
+    backgroundColor: 'transparent',
+  },
+  updatedAtContainer: {
+    gap: 8,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
   },
 });
 

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -48,20 +48,39 @@ const Library = ({ library, skipMetadata, showTrendingMark }: Props) => {
       ]}>
       <View style={styles.columnOne}>
         {library.unmaintained && (
-          <View style={[styles.updatedAtContainer, styles.trendingMarkContainer]}>
+          <View
+            style={
+              isSmallScreen
+                ? [
+                    styles.containerColumn,
+                    styles.updatedAtContainerSmall,
+                    { marginBottom: 6, gap: 0 },
+                  ]
+                : [styles.updatedAtContainer, styles.trendingMarkContainer]
+            }>
             <UnmaintainedLabel alternatives={library.alternatives} />
             <UpdatedAtView library={library} />
           </View>
         )}
         {showTrendingMark && library.popularity && (
-          <View style={[styles.updatedAtContainer, { marginBottom: 4 }]}>
+          <View
+            style={
+              isSmallScreen
+                ? [styles.containerColumn, styles.updatedAtContainerSmall]
+                : [styles.updatedAtContainer, { marginBottom: 4 }]
+            }>
             <Tooltip sideOffset={8} trigger={<TrendingMark library={library} />}>
               Trending Score is based on the last week to last month download rate.
             </Tooltip>
             {!library.unmaintained && <UpdatedAtView library={library} />}
           </View>
         )}
-        <View style={isSmallScreen ? styles.containerColumn : styles.updatedAtContainer}>
+        <View
+          style={
+            isSmallScreen
+              ? [styles.containerColumn, styles.updatedAtContainerSmall]
+              : styles.updatedAtContainer
+          }>
           <A
             href={library.githubUrl || github.urls.repo}
             style={styles.name}
@@ -78,11 +97,7 @@ const Library = ({ library, skipMetadata, showTrendingMark }: Props) => {
             <Headline numberOfLines={skipMetadata && 3} style={{ fontWeight: 300, lineHeight: 23 }}>
               <Linkify
                 options={{
-                  linkWrapper: ({ children, key, ...rest }) => (
-                    <A {...rest} key={key}>
-                      {children}
-                    </A>
-                  ),
+                  linkWrapper: ({ children, ...rest }) => <A {...rest}>{children}</A>,
                 }}>
                 {emoji.emojify(github.description)}
               </Linkify>
@@ -257,6 +272,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-start',
     justifyContent: 'space-between',
+  },
+  updatedAtContainerSmall: {
+    gap: 8,
+    justifyContent: 'flex-start',
+    alignSelf: 'flex-start',
   },
 });
 

--- a/pages/popular.tsx
+++ b/pages/popular.tsx
@@ -66,13 +66,6 @@ const Popular = ({ data }) => {
           filter={lib => lib.macos === true}
         />
         <ExploreSection
-          title="Expo Go"
-          icon={PlatformExpo}
-          data={data}
-          filter={lib => lib.expoGo === true}
-        />
-        <ExploreSection title="Fire OS" data={data} filter={lib => lib.fireos === true} />
-        <ExploreSection
           title="tvOS"
           icon={PlatformTvOS}
           data={data}
@@ -90,6 +83,13 @@ const Popular = ({ data }) => {
           data={data}
           filter={lib => lib.windows === true}
         />
+        <ExploreSection
+          title="Expo Go"
+          icon={PlatformExpo}
+          data={data}
+          filter={lib => lib.expoGo === true}
+        />
+        <ExploreSection title="Fire OS" data={data} filter={lib => lib.fireos === true} />
       </ContentContainer>
     </>
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

Recently, the metadata column grow a bit, extending the height of many libraries boxes. 

In this changeset I'm proposing moving the "update at" information to the top right corner of the library. The date will also appear now on the popular page tiles. To avoid repetition, I have converted the text label into tooltip on the icon and `aria-label` for accessibility on the node (just like we do with "Directory Score" meta information).

Additionally, I have used the warning theme to emphasize a bit the date for unmaintained packages.

# ✅ Checklist

- [x] Documented in this PR how you fixed or created the feature.

# Preview

* https://react-native-directory-emrid39ap-rndir.vercel.app/

### Images

![Screenshot 2025-04-01 at 14 28 44](https://github.com/user-attachments/assets/1384e427-748c-49bd-9c9f-d6210a8edef0)

![Screenshot 2025-04-01 at 14 29 11](https://github.com/user-attachments/assets/4f8e1750-533f-41d6-80a3-cfeeefa2289c)

![Screenshot 2025-04-01 at 14 43 04](https://github.com/user-attachments/assets/96fc59a8-41c3-416b-ba06-6c701b9d1150)

![Screenshot 2025-04-01 at 14 38 29](https://github.com/user-attachments/assets/134b88fd-268d-4953-ae6c-9ecd7a6d242d)
