### PR TITLE
Update `rive-react-native`'s New Architecture Compatibility via Interop Layer

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -11299,7 +11299,8 @@
     "examples": ["https://github.com/rive-app/rive-react-native/tree/main/example"],
     "android": true,
     "ios": true,
-    "newArchitecture": false
+    "newArchitecture": true,
+    "newArchitectureNote": "Currently supported through the new renderer interop layer."
   },
   {
     "githubUrl": "https://github.com/beaverfy/react-native-wear",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
`rive-react-native` is still labeled as incompatible with the new architecture, even though it now works thanks to the interop layer. Their example app is built with Expo and has the new architecture enabled: https://github.com/rive-app/rive-react-native/blob/8db519e65f5cfad91f7286c7c3c03334665b18c0/example/app.json#L10

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
