### PR TITLE
Added rn-use-google-places-autocomplete to **`react-native-libraries.json`**

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14379,5 +14379,22 @@
     ],
     "ios": true,
     "android": true
+  },
+  {
+  "githubUrl": "https://github.com/dpakakpo4/rn-use-google-places-autocomplete",
+  "npmPkg": "https://www.npmjs.com/package/rn-use-google-places-autocomplete",
+  "ios": true,
+  "android": true,
+  "web": false,
+  "windows": false,
+  "macos": false,
+  "tvos": false,
+  "visionos": false,
+  "expoGo": true,
+  "fireos": false,
+  "unmaintained": false,
+  "dev": false,
+  "template": false,
+  "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Added new npm package for react-native

https://www.npmjs.com/package/rn-use-google-places-autocomplete

# 📝 Why & how
I added a new npm package for react-native Android and iOS that can be used to work with the new Google Maps Places API.


# ✅ Checklist
- [X] Added library to react-native-libraries.json