### PR TITLE
fix: confirm lucide-react-native working on newArch

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -11363,7 +11363,8 @@
   {
     "githubUrl": "https://github.com/lucide-icons/lucide/tree/main/packages/lucide-react-native",
     "android": true,
-    "ios": true
+    "ios": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/maitrungduc1410/react-native-loader-kit",


### PR DESCRIPTION
# 📝 Why & how
Was getting the warn message on expo doctor that lucide-react-native was untested on the new Architecture, so I have gone ahead and added it to my app which worked perfectly fine. So I can confirm it works.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
