### PR TITLE
Updated package details for clerk, convex, svix

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -13669,6 +13669,30 @@
     "ios": true
   },
   {
+    "githubUrl": "https://github.com/clerkinc/javascript",
+    "npmPkg": "@clerk/types",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/get-convex/convex-js",
+    "npmPkg": "convex",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/svix/svix-example",
+    "npmPkg": "svix",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
+  },
+  {
     "githubUrl": "https://github.com/react-native-documents/document-picker/tree/main/packages/document-viewer",
     "npmPkg": "@react-native-documents/viewer",
     "examples": ["https://github.com/rnmods/react-native-document-picker/tree/master/example"],


### PR DESCRIPTION
# 📝 Why & how

Received below warning:
**✖ Validate packages against React Native Directory package metadata**
The following issues were found when validating your dependencies against React Native Directory:
  No metadata available: **@clerk/types, convex, svix**
Advice:

- Update React Native Directory to include metadata for unknown packages.
- Alternatively, set expo.doctor.reactNativeDirectoryCheck.listUnknownPackages in package.json to false to skip warnings about packages with no metadata, if the warning is not relevant.

This PR adds three new libraries to the React Native Library Directory:
- **Clerk:** TypeScript types for Clerk's authentication system.
- **Convex:** Backend platform with real-time sync for web and mobile apps.
- **Svix:** Enterprise-grade webhooks infrastructure service.

# ✅ Checklist
- [X] Added library to **`react-native-libraries.json`**
- [X] Updated library in **`react-native-libraries.json`**
