### PR TITLE
Added expo-background-task library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14544,5 +14544,12 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },{
+    "githubUrl": "https://github.com/expo/expo/tree/main/packages/expo-background-task",
+    "examples": ["https://docs.expo.dev/versions/latest/sdk/background-task/#usage"],
+    "ios": true,
+    "android": true,
+    "expoGo": false,
+    "newArchitecture": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14544,12 +14544,12 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
-  },{
+  },
+  {
     "githubUrl": "https://github.com/expo/expo/tree/main/packages/expo-background-task",
     "examples": ["https://docs.expo.dev/versions/latest/sdk/background-task/#usage"],
     "ios": true,
     "android": true,
-    "expoGo": false,
     "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Added expo-background-task library to the react-native-libraries.json file.

# 📝 Why & how

Library is new and updated and needs to be added to the directory.

# ✅ Checklist
- [x] Added library to **`react-native-libraries.json`**
