### PR TITLE
Update: removed expo-go from expo-background-fetch

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -2653,7 +2653,6 @@
     "examples": ["https://docs.expo.dev/versions/latest/sdk/background-fetch/#usage"],
     "ios": true,
     "android": true,
-    "expoGo": false,
     "newArchitecture": true
   },
   {

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -2653,7 +2653,7 @@
     "examples": ["https://docs.expo.dev/versions/latest/sdk/background-fetch/#usage"],
     "ios": true,
     "android": true,
-    "expoGo": true,
+    "expoGo": false,
     "newArchitecture": true
   },
   {


### PR DESCRIPTION
# 📝 Why & how

Expo Go is no longer supported in SDK 53 for this library

# ✅ Checklist
- [x] Updated library in **`react-native-libraries.json`**
