### PR TITLE
feat: add @rudderstack libraries in react-native-libraries.json

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14633,5 +14633,72 @@
     "android": true,
     "web": true,
     "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/sdk",
+    "npmPkg": "@rudderstack/rudder-sdk-react-native",
+    "ios": true,
+    "android": true,
+    "tvos": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/plugins/rudder-plugin-db-encryption-react-native",
+    "npmPkg": "@rudderstack/rudder-plugin-db-encryption-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-amplitude-react-native",
+    "npmPkg": "@rudderstack/rudder-integration-amplitude-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-appcenter-react-native",
+    "npmPkg": "@rudderstack/rudder-integration-appcenter-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-appsflyer-react-native",
+    "npmPkg": "@rudderstack/rudder-integration-appsflyer-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-braze-react-native",
+    "npmPkg": "@rudderstack/rudder-integration-braze-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-clevertap-react-native",
+    "npmPkg": "@rudderstack/rudder-integration-clevertap-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-facebook-react-native",
+    "npmPkg": "@rudderstack/rudder-integration-facebook-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-firebase-react-native",
+    "npmPkg": "@rudderstack/rudder-integration-firebase-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-moengage-react-native",
+    "npmPkg": "@rudderstack/rudder-integration-moengage-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-singular-react-native",
+    "npmPkg": "@rudderstack/rudder-integration-singular-react-native",
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

This PR adds multiple RudderStack React Native libraries in the `react-native-libraries.json`. Here is the list of libraries:
1. @rudderstack/rudder-sdk-react-native
2. @rudderstack/rudder-plugin-db-encryption-react-native
3. @rudderstack/rudder-integration-amplitude-react-native
4. @rudderstack/rudder-integration-appcenter-react-native
5. @rudderstack/rudder-integration-appsflyer-react-native
6. @rudderstack/rudder-integration-braze-react-native
7. @rudderstack/rudder-integration-clevertap-react-native
8. @rudderstack/rudder-integration-facebook-react-native
9. @rudderstack/rudder-integration-firebase-react-native
10. @rudderstack/rudder-integration-moengage-react-native
11. @rudderstack/rudder-integration-singular-react-native

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**