### PR TITLE
fix incorrect entries in libraries file

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -608,18 +608,6 @@
     ]
   },
   {
-    "githubUrl": "https://github.com/oblador/react-native-vector-icons",
-    "images": [
-      "https://cloud.githubusercontent.com/assets/378279/8903470/a9fe6b46-3458-11e5-901f-98b7b676d0d3.png"
-    ],
-    "ios": true,
-    "android": true,
-    "web": true,
-    "expoGo": true,
-    "macos": true,
-    "windows": true
-  },
-  {
     "githubUrl": "https://github.com/expo/vector-icons",
     "npmPkg": "@expo/vector-icons",
     "ios": true,
@@ -1253,12 +1241,18 @@
     "npmPkg": "react-native-calendar-picker"
   },
   {
-    "githubUrl": "https://github.com/byteburgers/react-native-autocomplete-input",
+    "githubUrl": "https://github.com/byteburgers/react-native-autocomplete-input/tree/main/packages/react-native-autocomplete-input",
+    "examples": [
+      "https://github.com/byteburgers/react-native-autocomplete-input/tree/main/examples/StarWarsMovieFinder",
+      "https://snack.expo.dev/@mrlaessig/rn-autocomplete-input-example"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/mrlaessig/react-native-autocomplete-input/master/example.gif"
+    ],
     "ios": true,
     "android": true,
     "web": true,
-    "expoGo": true,
-    "examples": ["https://snack.expo.dev/rJxdeFIIb"]
+    "expoGo": true
   },
   {
     "githubUrl": "https://github.com/aksonov/react-native-tabs",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

Fixes #1627

Update `react-native-autocomplete-input` entry and remove legacy `react-native-vector-icons` barrel package.

We would discuss how we want to handle new scoped icons packages approach, we might ignore them on the Expo CLI/Doctor side, just like we do in few other cases, see:
* https://github.com/expo/expo/blob/7361fa56e682128e57c08587ddf1040b31b2efc2/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts#L10-L20
* https://github.com/expo/expo/blob/7361fa56e682128e57c08587ddf1040b31b2efc2/packages/%40expo/cli/src/install/utils/checkPackagesCompatibility.ts#L18-L21

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**