### PR TITLE
Add entry for @google/genai unified JS SDK

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14778,5 +14778,12 @@
     "expoGo": true,
     "newArchitecture": true,
     "fireos": true
+  },
+  {
+    "githubUrl": "https://github.com/googleapis/js-genai",
+    "npmPkg": "@google/genai",
+    "android": true,
+    "web": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how
This PR adds a new library '@google/genai' the unified JS SDk for all generative AI models of google (NOT JUST GEMINI, it gives access to veo, imagen and other models too).


# ✅ Checklist
- [X] Added library to **`react-native-libraries.json`**
