### PR TITLE
Add `newArchitecture` support for tamagui

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -12649,7 +12649,8 @@
     ],
     "android": true,
     "ios": true,
-    "web": true
+    "web": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/EdgarJMesquita/react-native-webp-converter",


### PR DESCRIPTION
# 📝 Why & how
Tamagui main example uses expo SDK 53
https://github.com/tamagui/tamagui/pull/3424

Expo SDK 53 is using the new arch by default
https://expo.dev/changelog/sdk-53#the-new-architecture-is-now-default-everywhere


# ✅ Checklist
- [x] Updated library in **`react-native-libraries.json`**