### PR TITLE
Add mitt to React Native Directory

### DIFF
--- a/assets/data.json
+++ b/assets/data.json
@@ -83680,6 +83680,13 @@
       "topicSearchString": "react-native amap maps mapview"
     },
     {
+      "githubUrl": "https://github.com/developit/mitt",
+      "ios": true,
+      "android": true,
+      "expoGo": true,
+      "npmPkg": "mitt"
+    },
+    {
       "githubUrl": "https://github.com/mixpanel/mixpanel-react-native",
       "examples": [
         "https://github.com/mixpanel/mixpanel-react-native/tree/master/Samples/ContextAPIMixpanel",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
This change adds the library mitt to the data.json file in the assets directory. Expo Doctor currently gives a warning about mitt metadata missing.


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ x ] Added library to **`react-native-libraries.json`**
