### PR TITLE
Add mitt to React Native Libraries

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4225,6 +4225,19 @@
     "examples": ["https://github.com/jibraniqbal666/react-native-fb-image-grid/tree/master/example"]
   },
   {
+    "githubUrl": "https://github.com/developit/mitt",
+    "examples": [
+     "http://codepen.io/developit/pen/rjMEwW?editors=0110"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true,
+    "hasNativeModule": false,
+    "newArchitecture": false,
+    "npmPkg": "mitt"
+  },
+  {
     "githubUrl": "https://github.com/mongodb/stitch-js-sdk/tree/master/packages/react-native/sdk",
     "ios": true,
     "android": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4225,19 +4225,6 @@
     "examples": ["https://github.com/jibraniqbal666/react-native-fb-image-grid/tree/master/example"]
   },
   {
-    "githubUrl": "https://github.com/developit/mitt",
-    "examples": [
-     "http://codepen.io/developit/pen/rjMEwW?editors=0110"
-    ],
-    "ios": true,
-    "android": true,
-    "web": true,
-    "expoGo": true,
-    "hasNativeModule": false,
-    "newArchitecture": false,
-    "npmPkg": "mitt"
-  },
-  {
     "githubUrl": "https://github.com/mongodb/stitch-js-sdk/tree/master/packages/react-native/sdk",
     "ios": true,
     "android": true,
@@ -15520,5 +15507,15 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/developit/mitt",
+    "examples": [
+     "http://codepen.io/developit/pen/rjMEwW?editors=0110"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->
This PR adds mitt to the React Native Libraries to remove the Expo Doctor warning related to metadata. Mitt is a lightweight functional event emitter/ pubsub with no dependencies.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [X] Added library to **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
