### PR TITLE
Update Victory Native githubURL to include README info

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1091,12 +1091,13 @@
     "unmaintained": true
   },
   {
-    "githubUrl": "https://github.com/FormidableLabs/victory-native-xl/tree/main/lib",
+    "githubUrl": "https://github.com/FormidableLabs/victory-native-xl",
     "npmPkg": "victory-native",
     "ios": true,
     "android": true,
     "web": true,
-    "expoGo": true
+    "expoGo": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/mastermoo/react-native-action-button",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
This changes the githubURL of the Victory Native package. This way it includes the description, which helps when searching for 'chart' for example.

Currently, it's empty:  
![image](https://github.com/user-attachments/assets/8f463e4c-d11d-4882-b135-6ee204d1820e)



# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
