### PR TITLE
fix(better-auth): add missing npmPkg field

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14555,6 +14555,7 @@
   },
   {
     "githubUrl": "https://github.com/better-auth/better-auth/tree/main/packages/better-auth",
+    "npmPkg": "better-auth",
     "ios": true,
     "android": true,
     "expoGo": true,


### PR DESCRIPTION
# 📝 Why & how
When I added the better-auth library I forgot to include the npmPkg field so this pr adds that


# ✅ Checklist

- [ ]  Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**
