### PR TITLE
Add react-native-apikit to directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -16055,5 +16055,12 @@
     ],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/SamadK01/apikit",
+    "npmPkg": "react-native-apikit",
+    "ios": true,
+    "android": true,
+    "examples": []
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -16060,7 +16060,6 @@
     "githubUrl": "https://github.com/SamadK01/apikit",
     "npmPkg": "react-native-apikit",
     "ios": true,
-    "android": true,
-    "examples": []
+    "android": true
   }
 ]


### PR DESCRIPTION
This PR adds the react-native-apikit library to the React Native Directory. The package is up-to-date and supports both iOS and Android.