### PR TITLE
Add expo-android-keyboard-fix library to directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -16061,5 +16061,10 @@
     "npmPkg": "react-native-apikit",
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/eggmun98/expo-android-keyboard-fix",
+    "npmPkg": "expo-android-keyboard-fix",
+    "android": true
   }
 ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

This PR adds the **[expo-android-keyboard-fix](https://github.com/eggmun98/expo-android-keyboard-fix)** Expo Config Plugin to the React Native Directory. This plugin addresses the issue where `KeyboardAvoidingView` does not correctly handle keyboard insets on Android 15+ (SDK 35+), causing input fields to be obscured due to edge-to-edge UI behavior. It solves this problem by automatically injecting the necessary native Android code into Expo Managed Workflow apps to properly adjust the root view's padding when the keyboard appears.


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
