### PR TITLE
add: react-native-barcode, otpauth

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -16256,5 +16256,21 @@
     "web": true,
     "expoGo": true,
     "newArchitecture": true
+  },
+  {
+    "npmPkg": "@aramir/react-native-barcode",
+    "githubUrl": "https://github.com/aramir/react-native-barcode",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
+  },
+  {
+    "npmPkg": "otpauth",
+    "githubUrl": "https://github.com/hectorm/otpauth",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

Added `@aramir/react-native-barcode` and `otpauth`. Both tested working in expo/rn app on all devices.

> `@aramir/react-native-barcode` is a fork of existing but abandoned `@kichiyaki/react-native-barcode-generator`

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
