### PR TITLE
Add react-native-feather-toast to directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -16305,5 +16305,14 @@
     "android": true,
     "web": true,
     "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/kazimshah39/react-native-feather-toast",
+    "npmPkg": "react-native-feather-toast",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Title: Add react-native-feather-toast to directory

Description:
This PR adds the `react-native-feather-toast` package to the React Native Directory.
It's a lightweight toast library using Feather icons, compatible with iOS, Android, Web, and Expo Go.