### PR TITLE
Add `react-native-scroll-to-child`

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -16389,5 +16389,13 @@
     "android": true,
     "expoGo": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/filiphsps/react-native-scroll-to-child",
+    "npmPkg": "react-native-scroll-to-child",
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Added the package `react-native-scroll-to-child` which is hard-forked with new features and some API-changes as the original (`react-native-scroll-into-view`) hasn't been touched for a number of years now. 

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [X] Added library to **`react-native-libraries.json`**
