### PR TITLE
add ISC license reference

### DIFF
--- a/debug-github-repos.json
+++ b/debug-github-repos.json
@@ -51,5 +51,9 @@
     "githubUrl": "https://github.com/rnc-archive/react-native-drawer-layout",
     "expoGo": true,
     "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/kazimshah39/react-native-feather-toast",
+    "expoGo": true
   }
 ]

--- a/scripts/fetch-github-data.ts
+++ b/scripts/fetch-github-data.ts
@@ -13,7 +13,14 @@ import GitHubRepositoryQuery from './queries/GitHubRepositoryQuery';
 
 config();
 
-const licenses = {};
+const licenses = {
+  isc: {
+    name: 'ISC License',
+    url: 'https://www.isc.org/licenses/',
+    key: 'isc',
+    spdxId: 'ISC',
+  },
+};
 
 /**
  * Fetch licenses from GitHub to be used later to parse licenses from npm


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

Due to GitHub license endpoint not listing ISC license some of the packages were marked up as not-licensed incorrectly.

In the process I have also looked ad parsing package mentioned in:
* https://github.com/react-native-community/directory/issues/604

Unfortunately, looks like this packages relies on external data which basically matches what we get from GitHub licenses endpoint, so it marks basically the package usage as redundant.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [ ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
