### PR TITLE
Added rn-toptabs library to directory list

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -16867,5 +16867,26 @@
     "examples": ["https://github.com/mybigday/llama.rn/tree/main/example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/iymra-org/rn-toptabs",
+    "npmPkg": "rn-toptabs",
+    "examples": [
+      "https://github.com/iymra-org/rn-toptabs?tab=readme-ov-file#usage-example",
+    ],
+    "images": ["https://github.com/iymra-org/rn-toptabs?tab=readme-ov-file#usage-example"],
+    "ios": true,
+    "android": true,
+    "web": false,
+    "windows": false,
+    "macos": false,
+    "tvos": false,
+    "visionos": false,
+    "expoGo": false,
+    "fireos": false,
+    "unmaintained": false,
+    "dev": false,
+    "template": false,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
📝 Why & How
This PR adds the rn-toptabs library to the ecosystem.
It provides a lightweight and customizable top tab navigation component for React Native apps, making it easier to implement tab-based layouts with minimal setup.


✅ Checklist
 Added rn-toptabs to react-native-libraries.json
 Documented usage of the library (basic setup + example)
 Verified that the library works with the latest React Native version