### PR TITLE
Update react-native-libraries.json with @Gautham495/react-native-app-clip-overlay

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -17024,5 +17024,18 @@
     ],
     "ios": true,
     "newArchitecture": true
+  },
+    {
+    "githubUrl": "https://github.com/Gautham495/react-native-app-clip-overlay",
+    "npmPkg": "Gautham495/react-native-app-clip-overlay",
+    "examples": [
+      "https://github.com/Gautham495/react-native-app-clip-overlay/example",
+    ],
+    "ios": true,
+    "android": false,
+    "newArchitecture": true
   }
 ]
+
+
+


### PR DESCRIPTION
# 📝 Why & how

I am adding a new library called react-native-app-clip-overlay which can be used inside an app-clip in a react native app.

Inside an app clip, a native overlay can be shown by calling the native StoreKit Overlay functions, I have created in this library from the App clip's JS side, which when tapped on, will open up the Apple appstore all within the app-clip itself, which will reduce the number of steps taken by the uses to download the full app.

# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [x] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

<!-- If you added a feature or fixed a bug -->
- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
