### PR TITLE
account for missing `matchScore` in preprocessed data

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -113,7 +113,7 @@ export type LibraryType = LibraryDataEntryType & {
   matchingScoreModifiers: string[];
   topicSearchString: string;
   popularity?: number;
-  matchScore: number;
+  matchScore?: number;
 };
 
 export type LibraryDataEntryType = {

--- a/util/sorting.ts
+++ b/util/sorting.ts
@@ -35,10 +35,13 @@ export function popularity(libraries: LibraryType[]) {
 
 export function relevance(libraries: LibraryType[]) {
   return libraries.sort((a, b) => {
-    if (Math.abs(a.matchScore - b.matchScore) >= 50) {
-      return b.matchScore - a.matchScore;
-    }
+    if (a.matchScore && b.matchScore) {
+      if (Math.abs(a.matchScore - b.matchScore) >= 50) {
+        return b.matchScore - a.matchScore;
+      }
 
-    return b.score - a.score;
+      return b.score - a.score;
+    }
+    return 0;
   });
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

Fixes #1896

Next checks the types as a part of the build process, and due to additional data processing before deployment it has been failing on CI while passing locally.

# ✅ Checklist

- [x] Documented in this PR how you fixed an issue or created the feature.
