### PR TITLE
fix library purge check, sort topic counts

### DIFF
--- a/scripts/build-and-score-data.ts
+++ b/scripts/build-and-score-data.ts
@@ -219,15 +219,19 @@ async function buildAndScoreData() {
           }
     );
 
-    const finalData = dataWithFallback.filter(({ npmPkg }) => !existingPackages.includes(npmPkg));
+    const finalData = dataWithFallback.filter(({ npmPkg }) => existingPackages.includes(npmPkg));
     const validEntries = data.map((entry: LibraryDataEntryType) => entry.githubUrl);
+
+    const sortedTopicCounts = Object.fromEntries(
+      Object.entries(topicCounts).sort((a, b) => b[1] - a[1])
+    );
 
     fileContent = JSON.stringify(
       {
         libraries: finalData.filter((entry: LibraryType) => {
           return validEntries.includes(entry.githubUrl);
         }),
-        topics: topicCounts,
+        topics: sortedTopicCounts,
         topicsList: Object.keys(topicCounts).sort(),
       },
       null,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how

I have spotted that after recent changes old libraries purge logic is not working correctly, which will be fixed now. Also, I have added a topics search count object sort, so the most common ones always appears at the beginning of the object.

# ✅ Checklist

- [x] Documented in this PR how you fixed an issue or created the feature.
