### PR TITLE
Add munim-ffmpeg

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -22548,6 +22548,17 @@
     "configPlugin": true
   },
   {
+    "githubUrl": "https://github.com/munimtechnologies/munim-ffmpeg",
+    "npmPkg": "munim-ffmpeg",
+    "examples": ["https://github.com/munimtechnologies/munim-ffmpeg/tree/HEAD/example"],
+    "ios": true,
+    "android": true,
+    "expoGo": false,
+    "newArchitecture": "new-arch-only",
+    "newArchitectureNote": "Built with Nitro Modules; the old architecture is not supported.",
+    "configPlugin": true
+  },
+  {
     "githubUrl": "https://github.com/mfairley/expo-callkit-telecom",
     "examples": ["https://github.com/mfairley/expo-callkit-telecom/tree/main/example"],
     "configPlugin": true,

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -22544,18 +22544,6 @@
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only",
-    "newArchitectureNote": "Built with Nitro Modules; the old architecture is not supported.",
-    "configPlugin": true
-  },
-  {
-    "githubUrl": "https://github.com/munimtechnologies/munim-ffmpeg",
-    "npmPkg": "munim-ffmpeg",
-    "examples": ["https://github.com/munimtechnologies/munim-ffmpeg/tree/HEAD/example"],
-    "ios": true,
-    "android": true,
-    "expoGo": false,
-    "newArchitecture": "new-arch-only",
-    "newArchitectureNote": "Built with Nitro Modules; the old architecture is not supported.",
     "configPlugin": true
   },
   {
@@ -24128,5 +24116,13 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/munimtechnologies/munim-ffmpeg",
+    "examples": ["https://github.com/munimtechnologies/munim-ffmpeg/tree/HEAD/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only",
+    "configPlugin": true
   }
 ]


### PR DESCRIPTION
Adds [munim-ffmpeg](https://github.com/munimtechnologies/munim-ffmpeg), FFmpeg and FFprobe for React Native and Expo, built on Nitro Modules.

- Ships **FFmpeg 9.0.1** built from ffmpeg.org for both platforms — iOS arm64 plus arm64/x86_64 simulator, Android arm64-v8a, armeabi-v7a and x86_64 (16 KB aligned).
- New architecture only, via Nitro Modules; includes an Expo config plugin.
- LGPL: no x264/x265, so apps do not inherit GPL obligations. H.264/HEVC use VideoToolbox and MediaCodec, with openh264 as a software fallback.
- Example app runs a 25-check device suite; verified on an iPad Air (M3), the iOS Simulator and a Galaxy A14 5G.