### PR TITLE
Add timbre — libmpv-based React Native audio library (4 packages)

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24147,5 +24147,33 @@
     "ios": true,
     "android": true,
     "expoGo": true
+  },
+  {
+    "githubUrl": "https://github.com/afkcodes/timbre/tree/main/packages/player",
+    "npmPkg": "@afkcodes/timbre-player",
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/afkcodes/timbre/tree/main/packages/media-session",
+    "npmPkg": "@afkcodes/timbre-media-session",
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/afkcodes/timbre/tree/main/packages/audio-session",
+    "npmPkg": "@afkcodes/timbre-audio-session",
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/afkcodes/timbre/tree/main/packages/cast",
+    "npmPkg": "@afkcodes/timbre-cast",
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only"
   }
 ]


### PR DESCRIPTION
Adds **timbre**, a React Native audio library built on [libmpv](https://mpv.io) via [Nitro Modules](https://nitro.margelo.com), as four independent packages:

- `@afkcodes/timbre-player` — libmpv-backed audio player: gapless queue, equaliser, ReplayGain, rate/pitch, typed events + error taxonomy
- `@afkcodes/timbre-media-session` — player-agnostic media session (lock screen, notification, Bluetooth, survives process death); media3 on Android, MPNowPlayingInfoCenter/MPRemoteCommandCenter on iOS
- `@afkcodes/timbre-audio-session` — audio focus, ducking, interruptions, becoming-noisy, route changes
- `@afkcodes/timbre-cast` — Chromecast sender

All four are published to npm, iOS + Android, new-architecture only (Nitro). 

Repo: https://github.com/afkcodes/timbre · Docs: https://afkcodes.github.io/timbre