### PR TITLE
Add munim-wifi

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24176,5 +24176,13 @@
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/munimtechnologies/munim-wifi",
+    "examples": ["https://github.com/munimtechnologies/munim-wifi/tree/HEAD/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only",
+    "configPlugin": true
   }
 ]


### PR DESCRIPTION
Adds [munim-wifi](https://github.com/munimtechnologies/munim-wifi) — fast Wi-Fi scanning, connection, and network information for Expo and React Native, powered by Nitro Modules.

- iOS + Android, New Architecture only (Nitro Modules)
- Ships an Expo config plugin (`app.plugin.js`)
- Example app included in the repo
- npm: https://www.npmjs.com/package/munim-wifi

🤖 Generated with [Claude Code](https://claude.com/claude-code)