### PR TITLE
Add munim-pencilkit

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24176,5 +24176,12 @@
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/munimtechnologies/munim-pencilkit",
+    "examples": ["https://github.com/munimtechnologies/munim-pencilkit/tree/HEAD/example"],
+    "ios": true,
+    "newArchitecture": "new-arch-only",
+    "configPlugin": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds [munim-pencilkit](https://github.com/munimtechnologies/munim-pencilkit) — a React Native library (Nitro Modules, New Architecture only) that exposes Apple PencilKit drawing views with comprehensive Apple Pencil support (pressure, tilt, predicted/coalesced touches, haptics). Published on npm as [`munim-pencilkit`](https://www.npmjs.com/package/munim-pencilkit).

- iOS only (PencilKit is an Apple framework)
- New Architecture only (Nitro-based)
- Includes an Expo config plugin (`app.plugin.js`); requires a dev client / prebuild, so not compatible with Expo Go
- Entry added at the end of `react-native-libraries.json` per the contributing guide

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)