### PR TITLE
Mark rn-story as supporting the New Architecture

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24087,7 +24087,8 @@
     "images": ["https://raw.githubusercontent.com/AbdullahAnsarii/rn-story/master/docs/demo.jpg"],
     "ios": true,
     "android": true,
-    "web": true
+    "web": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/ksblazh/expo-tts-file",


### PR DESCRIPTION
# 📝 Why & how

Sets `newArchitecture: true` on the existing `rn-story` entry (added in #2763).

rn-story is pure JavaScript with no native code of its own, so it has nothing architecture-specific to migrate. Its only native dependency — `expo-av`, consumed as a peer dependency — runs under the New Architecture on the Expo SDKs that ship it (SDK 52+, where the New Architecture is the default). The library's example app and Snack demo target SDK 54.

This clears the "?" New Architecture badge on the listing and the `expo doctor` "Untested on New Architecture" warning for projects using the package.

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**