### PR TITLE
Add react-native-continued-task

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24215,5 +24215,11 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/mahdidavoodi7/react-native-continued-task",
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Adds [react-native-continued-task](https://github.com/mahdidavoodi7/react-native-continued-task) — background tasks that keep running after the app is backgrounded, wrapping iOS 26's `BGContinuedProcessingTask` and Android's WorkManager foreground services behind one API.

- npm: https://www.npmjs.com/package/react-native-continued-task
- iOS (26+) and Android, New Architecture, Nitro Modules (Swift + Kotlin)
- Ships an Expo config plugin; requires a dev build, so no Expo Go

Entry appended at the end of `react-native-libraries.json` per the README, with only the applicable true values.