### PR TITLE
Add @pushengage/pushengage-react-native

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24207,5 +24207,13 @@
     "githubUrl": "https://github.com/devusimple/ytdlp-react-native",
     "newArchitecture": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/awesomemotive/pushengage-react-native",
+    "npmPkg": "@pushengage/pushengage-react-native",
+    "examples": ["https://github.com/awesomemotive/pushengage-react-native/tree/master/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds the PushEngage React Native SDK (`@pushengage/pushengage-react-native`) to the directory. It provides push notifications and in-app messaging for iOS and Android, built as a Turbo Module (New Architecture).

- Entry appended at the end of `react-native-libraries.json`
- `npmPkg` set explicitly because the published package name differs from the repository name
- `examples` points to the `example/` app in the repository

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
