### PR TITLE
Update @lugg/maps to new-arch-only

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -23460,7 +23460,7 @@
       "https://github.com/lugg/maps/tree/main/example/bare",
       "https://github.com/lugg/maps/tree/main/example/expo"
     ],
-    "newArchitecture": true,
+    "newArchitecture": "new-arch-only",
     "ios": true,
     "android": true,
     "web": true


### PR DESCRIPTION
# 📝 Why & how

`@lugg/maps` is a Fabric-only library (see [installation docs](https://maps.lodev09.com/installation)). Set `newArchitecture` to `"new-arch-only"` instead of `true`.

# ✅ Checklist

- [x] Updated library in **`react-native-libraries.json`**