### PR TITLE
time range select for downloads sparkline chart, add animations

### DIFF
--- a/components/Package/DownloadsChart.tsx
+++ b/components/Package/DownloadsChart.tsx
@@ -1,7 +1,8 @@
 import { LinearGradient } from '@visx/gradient';
 import { ParentSize } from '@visx/responsive';
-import { AreaSeries, type AxisScale, Tooltip, XYChart } from '@visx/xychart';
+import { AnimatedAreaSeries, Tooltip, XYChart } from '@visx/xychart';
 import { maxBy } from 'es-toolkit/array';
+import { useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import useSWR from 'swr';
 
@@ -15,6 +16,7 @@ type Point = { date: Date; value: number };
 
 type Props = {
   packageName: string;
+  range: string;
   height?: number;
 };
 
@@ -25,9 +27,9 @@ const DATE_FORMAT = {
   year: '2-digit' as const,
 };
 
-export default function DownloadsChart({ packageName, height = 48 }: Props) {
+export default function DownloadsChart({ packageName, range, height = 48 }: Props) {
   const { data } = useSWR(
-    `/api/proxy/npm-stat?name=${packageName}`,
+    `/api/proxy/npm-stat?name=${packageName}&range=${range}`,
     (url: string) => fetch(url).then(res => res.json()),
     {
       dedupingInterval: TimeRange.HOUR * 1000,
@@ -35,7 +37,24 @@ export default function DownloadsChart({ packageName, height = 48 }: Props) {
     }
   );
 
-  const series = data && Object.keys(data).length ? mapData(data[packageName]) : null;
+  const series =
+    data && Object.keys(data).length ? mapData(data[packageName], range === 'year') : null;
+  const [animatedSeries, setAnimatedSeries] = useState<Point[] | null>(null);
+
+  useEffect(() => {
+    const nextSeries =
+      data && Object.keys(data).length ? mapData(data[packageName], range === 'year') : null;
+    if (!nextSeries) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      setAnimatedSeries(nextSeries.map(point => ({ ...point, value: 0 })));
+      requestAnimationFrame(() => setAnimatedSeries(nextSeries));
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [data, packageName, range]);
+
   const yDomain = getYDomain(series);
 
   return (
@@ -49,7 +68,7 @@ export default function DownloadsChart({ packageName, height = 48 }: Props) {
           );
         }
 
-        if (!width || !data || !series) {
+        if (!width || !data || !series || !animatedSeries) {
           return (
             <View style={tw`h-full items-center justify-center`}>
               <ThreeDotsLoader />
@@ -71,15 +90,23 @@ export default function DownloadsChart({ packageName, height = 48 }: Props) {
               fromOpacity={tw.prefixMatch('dark') ? 0.3 : 0.5}
               toOpacity={0}
             />
-            <AreaSeries<AxisScale, AxisScale, Point>
+            <AnimatedAreaSeries
               dataKey="area"
-              data={series}
+              data={animatedSeries}
               xAccessor={(p: Point) => p.date.getTime()}
               yAccessor={(p: Point) => p.value}
               fill="url(#area-gradient)"
             />
             <Tooltip<Point>
               showVerticalCrosshair
+              snapTooltipToDatumX
+              showDatumGlyph
+              glyphStyle={{
+                fill: COLOR,
+                stroke: 'white',
+                strokeWidth: 0.5,
+                r: 3,
+              }}
               verticalCrosshairStyle={{
                 stroke: COLOR,
                 strokeWidth: 0.5,
@@ -114,11 +141,31 @@ export default function DownloadsChart({ packageName, height = 48 }: Props) {
   );
 }
 
-function mapData(dataMap: DataMap): Point[] {
-  return Object.entries(dataMap).map(([date, value]) => ({
-    date: new Date(date + 'T00:00:00Z'),
+function mapData(dataMap: DataMap, aggregateByWeek: boolean): Point[] {
+  if (!aggregateByWeek) {
+    return Object.entries(dataMap).map(([date, value]) => ({
+      date: new Date(date + 'T00:00:00Z'),
+      value,
+    }));
+  }
+
+  const weeklyTotals = new Map<number, number>();
+  for (const [date, value] of Object.entries(dataMap)) {
+    const weekStart = getWeekStart(new Date(date + 'T00:00:00Z'));
+    const weekKey = weekStart.getTime();
+    weeklyTotals.set(weekKey, (weeklyTotals.get(weekKey) ?? 0) + value);
+  }
+
+  return [...weeklyTotals].map(([weekStart, value]) => ({
+    date: new Date(weekStart),
     value,
   }));
+}
+
+function getWeekStart(date: Date): Date {
+  const weekStart = new Date(date);
+  weekStart.setUTCDate(date.getUTCDate() - ((date.getUTCDay() + 6) % 7));
+  return weekStart;
 }
 
 function getYDomain(series: Point[] | null) {

--- a/components/Package/DownloadsSection.tsx
+++ b/components/Package/DownloadsSection.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+
+import { Caption, H6Section, HoverEffect, Label } from '~/common/styleguide';
+import TrendingMark from '~/components/Library/TrendingMark';
+import DownloadsChart from '~/components/Package/DownloadsChart';
+import { type LibraryType } from '~/types';
+import { getStoredValue } from '~/util/localStorage';
+import tw from '~/util/tailwind';
+
+type Props = {
+  library: LibraryType;
+};
+
+const DOWNLOAD_RANGE_KEY = '@ReactNativeDirectory:PackageScene:downloadRange';
+
+export default function DownloadsSection({ library }: Props) {
+  const [range, setRange] = useState(() => getStoredValue(DOWNLOAD_RANGE_KEY) ?? 'month');
+
+  return (
+    <View style={tw`gap-y-3`}>
+      <H6Section style={tw`flex items-center justify-between`}>
+        Downloads
+        <View style={tw`flex flex-row items-center gap-0.5`}>
+          <HoverEffect
+            onPress={() => {
+              setRange('month');
+              window.localStorage.setItem(DOWNLOAD_RANGE_KEY, 'month');
+            }}
+            style={tw`outline-offset-1`}>
+            <Label
+              style={[
+                tw`select-none font-light underline decoration-tertiary`,
+                range === 'month' ? tw`text-decoration-primary-dark` : tw`text-secondary`,
+              ]}>
+              Last month
+            </Label>
+          </HoverEffect>
+          <Label style={tw`font-light text-tertiary`}>{' · '}</Label>
+          <HoverEffect
+            onPress={() => {
+              setRange('year');
+              window.localStorage.setItem(DOWNLOAD_RANGE_KEY, 'year');
+            }}
+            style={tw`outline-offset-1`}>
+            <Label
+              style={[
+                tw`select-none font-light underline decoration-tertiary`,
+                range === 'year' ? tw`text-decoration-primary-dark` : tw`text-secondary`,
+              ]}>
+              Last year
+            </Label>
+          </HoverEffect>
+        </View>
+      </H6Section>
+      <View style={tw`h-[54px] gap-1.5 overflow-hidden rounded-lg border border-default`}>
+        <DownloadsChart packageName={library.npmPkg} range={range} />
+      </View>
+      <View style={tw`flex-row flex-wrap items-center justify-between`}>
+        <Caption style={tw`text-[13px] font-light`}>Popularity</Caption>
+        <TrendingMark library={library} />
+      </View>
+    </View>
+  );
+}

--- a/pages/api/proxy/npm-stat.ts
+++ b/pages/api/proxy/npm-stat.ts
@@ -4,9 +4,12 @@ import { DEFAULT_RESPONSE_CACHE_HEADER, NEXT_10M_CACHE_HEADER } from '~/util/Con
 import { TimeRange } from '~/util/datetime';
 import { parseQueryParams } from '~/util/queryParams';
 
+const VALID_TIME_RANGES = new Set(['month', 'year']);
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { name } = parseQueryParams(req.query);
+  const { name, range } = parseQueryParams(req.query);
   const packageName = name ? name.toString().toLowerCase().trim() : undefined;
+  const timeRange = range ? range.toString().toLowerCase().trim() : 'month';
 
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Cache-Control', DEFAULT_RESPONSE_CACHE_HEADER);
@@ -19,9 +22,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
+  if (timeRange && !VALID_TIME_RANGES.has(timeRange)) {
+    res.statusCode = 500;
+    res.json({
+      error: `Invalid request. You need to specify a valid time range ('month' or 'year') via 'range' query param.`,
+    });
+    return;
+  }
+
+  const activeTimeRange = timeRange === 'year' ? TimeRange.YEAR : TimeRange.MONTH;
   const now = Date.now();
   const until = new Date(now).toISOString().slice(0, 10);
-  const from = new Date(now - TimeRange.MONTH * 1000).toISOString().slice(0, 10);
+  const from = new Date(now - activeTimeRange * 1000).toISOString().slice(0, 10);
 
   const result = await fetch(
     `https://npm-stat.com/api/download-counts?package=${packageName}&from=${from}&until=${until}`,

--- a/scenes/PackageOverviewScene.tsx
+++ b/scenes/PackageOverviewScene.tsx
@@ -2,16 +2,15 @@ import { UL } from '@expo/html-elements';
 import dynamic from 'next/dynamic';
 import { View } from 'react-native';
 
-import { A, Caption, H6Section, Label, useLayout } from '~/common/styleguide';
+import { A, H6Section, useLayout } from '~/common/styleguide';
 import ContentContainer from '~/components/ContentContainer';
 import MetaData from '~/components/Library/MetaData';
-import TrendingMark from '~/components/Library/TrendingMark';
 import UpdatedAtView from '~/components/Library/UpdatedAtView';
 import CollapsibleSection from '~/components/Package/CollapsibleSection';
 import CommunitySection from '~/components/Package/CommunitySection';
 import DependenciesSection from '~/components/Package/DependenciesSection';
 import DetailsNavigation from '~/components/Package/DetailsNavigation';
-import DownloadsChart from '~/components/Package/DownloadsChart';
+import DownloadsSection from '~/components/Package/DownloadsSection';
 import EntityCounter from '~/components/Package/EntityCounter';
 import ExampleBox from '~/components/Package/ExampleBox';
 import MarkdownContentBox from '~/components/Package/MarkdownContentBox';
@@ -88,18 +87,7 @@ export default function PackageOverviewScene({
                 <MetaData library={library} secondary skipExamples />
               </View>
             </CollapsibleSection>
-            <H6Section style={tw`flex items-center justify-between`}>
-              Downloads <Label style={tw`font-light text-secondary`}>Last month</Label>
-            </H6Section>
-            <View style={tw`gap-y-2`}>
-              <View style={tw`h-[54px] gap-1.5 overflow-hidden rounded-lg border border-default`}>
-                <DownloadsChart packageName={packageName} />
-              </View>
-              <View style={tw`flex-row flex-wrap items-center justify-between`}>
-                <Caption style={tw`text-[13px] font-light`}>Popularity</Caption>
-                <TrendingMark library={library} />
-              </View>
-            </View>
+            <DownloadsSection library={library} />
             <TopicsSection topics={library.github.topics} />
             <CollapsibleSection title="Package analysis">
               <ul


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

Add time range select for downloads sparkline chart, add chart animations, support range parameter in npm-stats proxy endpoint, store selected range by user in local storage. Small code reorganization/refactor.

# ✅ Checklist

- [x] Explained how you fixed the issue or built the feature.

# Preview

https://github.com/user-attachments/assets/83fdef3c-4d94-427a-b519-5b1f917b802e