### PR TITLE
Wrap navigation tabs on mobile

### DIFF
--- a/components/Package/DetailsNavigation.tsx
+++ b/components/Package/DetailsNavigation.tsx
@@ -57,7 +57,7 @@ export default function DetailsNavigation({ library }: Props) {
           </View>
         ) : undefined
       }>
-      <ContentContainer style={tw`flex-row gap-2 px-5`}>
+      <ContentContainer style={[tw`flex-row gap-2 px-5`, isSmallScreen && tw`flex-wrap`]}>
         <NavigationTab title="Overview" path={`/package/${library.npmPkg}`} />
         <NavigationTab
           title="Versions"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

Navigation tabs overflow on small screens. I added a conditional `flex-wrap` to solve it

| Before                                                                                                                                     | After                                                                                                                                     |
| ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="750" height="1812" alt="score_before" src="https://github.com/user-attachments/assets/ebaf024d-5e0c-45e9-8371-dfb1a9c2a189" /> | <img width="750" height="1812" alt="score_after" src="https://github.com/user-attachments/assets/5c650a17-ccd5-4a60-a254-9822e08997a4" /> |

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a new library or updated the existing one. -->

<!-- If you added a feature or fixed a bug -->

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.

<!-- Thanks again for helping improve the project! 🙏 -->
