### PR TITLE
Add orn-ui

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24227,5 +24227,18 @@
     "examples": ["https://github.com/armanrma7/react-native-callkit-telecom/tree/main/example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/DavidTrujillo123/orn-ui",
+    "npmPkg": "orn-ui",
+    "examples": ["https://github.com/DavidTrujillo123/orn-ui/tree/main/apps/example"],
+    "images": [
+      "https://orn-ui-docs.vercel.app/media/button.gif",
+      "https://orn-ui-docs.vercel.app/media/bottom-sheet.gif"
+    ],
+    "ios": true,
+    "android": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24229,7 +24229,7 @@
     "android": true
   },
   {
-    "githubUrl": "https://github.com/DavidTrujillo123/orn-ui",
+    "githubUrl": "https://github.com/DavidTrujillo123/orn-ui/tree/main/packages/ui",
     "npmPkg": "orn-ui",
     "examples": ["https://github.com/DavidTrujillo123/orn-ui/tree/main/apps/example"],
     "images": [


### PR DESCRIPTION
Adds `orn-ui` at the end of `react-native-libraries.json`, per the README.

Atomic-design component library for React Native and Expo: 44 typed
components (atoms, molecules, organisms), light/dark theming, zero runtime
dependencies.

Flags I set, and why:

- **`expoGo: true`** — there is no native code in the package at all, so it
  runs in Expo Go with no dev client and no prebuild. Verified in CI against
  Expo SDK 54, 55, 56 and 57, each with its own job running `tsc` plus the
  full test suite against that exact `react-native`/`react` pair.
- **`newArchitecture: true`** — same reason: no native modules, nothing to
  migrate. Peer range is `react-native >= 0.81`.
- **`ios` / `android`** — pure JS, works on both.
- **`web`** is intentionally left off: it is not tested against
  `react-native-web`, so I am not claiming it.

`dependencies` is empty; `react`, `react-native` and
`react-native-safe-area-context` are the only peers.

- Docs: https://orn-ui-docs.vercel.app
- npm: https://www.npmjs.com/package/orn-ui

Disclosure: this is my own library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HDDSem6KnSEXvUPGAsaSM
