### PR TITLE
Add @dahab-tech/react-native-media-editor

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24227,5 +24227,14 @@
     "examples": ["https://github.com/armanrma7/react-native-callkit-telecom/tree/main/example"],
     "ios": true,
     "android": true
+  },
+  {
+    "githubUrl": "https://github.com/Dahab-Tech/react-native-media-editor",
+    "npmPkg": "@dahab-tech/react-native-media-editor",
+    "examples": ["https://github.com/Dahab-Tech/react-native-media-editor/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "expoGo": false,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
Adds @dahab-tech/react-native-media-editor — a free, MIT-licensed photo & video editor SDK for Expo / React Native.

# 📝 Why & how

Adds **@dahab-tech/react-native-media-editor** — a free, MIT-licensed photo & video editor SDK for Expo / React Native.

- Photo: crop/straighten, 15 adjustments, 64 filters, overlays, selective focus, draw, text with per-line pill backgrounds, stickers, multi-photo batch
- Video: trim (lossless), crop, cover picker, filters/adjustments with live preview, playback speed, text/sticker/draw layers, opt-in compression
- Full RTL (English + Arabic built in), light/dark theming
- Ships an Expo config plugin; requires a development build (native code, no Expo Go)

npm: https://www.npmjs.com/package/@dahab-tech/react-native-media-editor
Example app: https://github.com/Dahab-Tech/react-native-media-editor/tree/main/example

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
