### PR TITLE
Add react-native-collapsible-tabs-native

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24248,5 +24248,17 @@
     "ios": true,
     "android": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/ramssutharr/react-native-collapsible-tabs-native",
+    "examples": [
+      "https://github.com/ramssutharr/react-native-collapsible-tabs-native/tree/main/example"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/ramssutharr/react-native-collapsible-tabs-native/main/docs/demo-ios.gif"
+    ],
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only"
   }
 ]


### PR DESCRIPTION
Native collapsible tabs for React Native (Fabric): collapsing header + pinned tab bar over a native pager, frame-synced with the list. iOS + Android, New Architecture only. Example app and demo GIF in the repo.