### PR TITLE
Add react-native-nitro-wakeword, update rn-custom-alert-prompt and rn-inkpad

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -11893,9 +11893,12 @@
   },
   {
     "githubUrl": "https://github.com/FerRiv3ra/rn-custom-alert-prompt",
+    "examples": ["https://github.com/FerRiv3ra/rn-custom-alert-prompt/tree/main/example"],
     "ios": true,
     "android": true,
-    "expoGo": true
+    "web": true,
+    "expoGo": true,
+    "newArchitecture": true
   },
   {
     "githubUrl": "https://github.com/FerRiv3ra/rn-segmented-tab-controls",
@@ -12098,8 +12101,10 @@
   },
   {
     "githubUrl": "https://github.com/FerRiv3ra/rn-inkpad",
+    "examples": ["https://github.com/FerRiv3ra/rn-inkpad/tree/main/example"],
     "ios": true,
     "android": true,
+    "web": true,
     "expoGo": true
   },
   {
@@ -24300,5 +24305,13 @@
     "web": true,
     "expoGo": true,
     "newArchitecture": true
+  },
+  {
+    "githubUrl": "https://github.com/FerRiv3ra/react-native-nitro-wakeword",
+    "examples": ["https://github.com/FerRiv3ra/react-native-nitro-wakeword/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "newArchitecture": "new-arch-only",
+    "configPlugin": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds one new library and updates two existing entries maintained by me.

**New: [react-native-nitro-wakeword](https://github.com/FerRiv3ra/react-native-nitro-wakeword)**
Open-source, on-device wake word detection for React Native. Runs the openWakeWord pipeline (mel spectrogram → speech embedding → keyword classifier) with ONNX Runtime, native audio capture on both platforms, powered by Nitro Modules (new architecture only). MIT licensed, no license keys. Ships an Expo config plugin (permissions + copies custom `.onnx` models into the native projects) and an example app. Published on npm as `react-native-nitro-wakeword` (0.2.0, with provenance).

**Updated: rn-custom-alert-prompt**
Added `examples` (repo has an Expo example app), `web` and `newArchitecture`, both documented in the README ("Works with the New Architecture and React Native Web").

**Updated: rn-inkpad**
Added `examples` and `web`: the example app targets web and CI builds it (`expo export --platform web`).

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**
- [x] Updated library in **`react-native-libraries.json`**
