### PR TITLE
Add Amplitude React Native packages and Expo dev plugins

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24260,5 +24260,34 @@
     "ios": true,
     "android": true,
     "newArchitecture": "new-arch-only"
+  },
+  {
+    "githubUrl": "https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-react-native",
+    "npmPkg": "@amplitude/analytics-react-native",
+    "ios": true,
+    "android": true,
+    "web": true
+  },
+  {
+    "githubUrl": "https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/plugin-session-replay-react-native",
+    "npmPkg": "@amplitude/plugin-session-replay-react-native",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/amplitude/experiment-react-native-client",
+    "npmPkg": "@amplitude/experiment-react-native-client",
+    "ios": true,
+    "android": true
+  },
+  {
+    "githubUrl": "https://github.com/expo/dev-plugins/tree/main/packages/apollo-client",
+    "npmPkg": "@dev-plugins/apollo-client",
+    "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/expo/dev-plugins/tree/main/packages/react-navigation",
+    "npmPkg": "@dev-plugins/react-navigation",
+    "dev": true
   }
 ]


### PR DESCRIPTION
Adds five open-source entries, all published to npm and in production use in a React Native app I work on. I am not the author of these packages.

**Amplitude (monorepo sub-paths point at the package `package.json`, per the note in the README):**

- `@amplitude/analytics-react-native` — iOS, Android, web
- `@amplitude/plugin-session-replay-react-native` — iOS, Android
- `@amplitude/experiment-react-native-client` — iOS, Android (standalone repo)

**Expo dev plugins** (devtools only, no native runtime, so flagged `dev`):

- `@dev-plugins/apollo-client`
- `@dev-plugins/react-navigation`

Entries are appended at the end of the file, `false` values are skipped, and auto-detected fields are left out. Verified locally: `ajv` validation against `react-native-libraries.schema.json` passes and `oxfmt --check` reports no formatting changes.
