### PR TITLE
Add @nikpnevmatikos/html-renderer

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -24290,5 +24290,15 @@
     "githubUrl": "https://github.com/expo/dev-plugins/tree/main/packages/react-navigation",
     "npmPkg": "@dev-plugins/react-navigation",
     "dev": true
+  },
+  {
+    "githubUrl": "https://github.com/NikPnevmatikos/Html-Renderer/tree/main/packages/core",
+    "npmPkg": "@nikpnevmatikos/html-renderer",
+    "examples": ["https://github.com/NikPnevmatikos/Html-Renderer/tree/main/example"],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true,
+    "newArchitecture": true
   }
 ]


### PR DESCRIPTION
# 📝 Why & how

Adds [`@nikpnevmatikos/html-renderer`](https://www.npmjs.com/package/@nikpnevmatikos/html-renderer), a React Native HTML renderer written in TypeScript with zero native modules.

- Runs on iOS, Android and web (`react-native-web`), and in Expo Go without a dev build.
- Pure JS/TS, so it works on both the New and Old Architecture.
- `stylesheet` prop that accepts real CSS with selectors and specificity, plus `tagsStyles`, `classesStyles`, custom renderers and DOM transform hooks.
- Lives in a monorepo; `githubUrl` points at `packages/core` so name, description and keywords are read from that package's `package.json`.
- Example app: https://github.com/NikPnevmatikos/Html-Renderer/tree/main/example

# ✅ Checklist

- [x] Added library to **`react-native-libraries.json`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
