### PR TITLE
Fix code block overflow

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -548,6 +548,7 @@ select {
   pre {
     margin-bottom: 0;
     overflow-x: auto;
+    scrollbar-color: var(--icon) var(--background);
 
     code {
       background-color: unset;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -547,6 +547,7 @@ select {
 
   pre {
     margin-bottom: 0;
+    overflow-x: auto;
 
     code {
       background-color: unset;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! 🙌 We really appreciate your time and effort in contributing to this project.
Please follow the template below to help reviewers understand your changes clearly. -->

# 📝 Why & how

<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->

Code block content overflows when longer text is rendered, mostly on mobile.

This is fixed by setting `<pre>` horizontal overflow to auto:

| Before                                                                                                                                    | After                                                                                                                                    |
| ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="750" height="1812" alt="code_before" src="https://github.com/user-attachments/assets/cf21f5fb-6c65-4930-a4cf-ae2e8b522dc3" /> | <img width="750" height="1812" alt="code_after" src="https://github.com/user-attachments/assets/7c5c3598-9b21-475d-b57c-da95c7ab8d61" /> |

# ✅ Checklist

<!-- Mark completed items with [x]. Remove tasks that don't apply. -->

<!-- If you added a feature or fixed a bug -->

- [x] Documented how you found or replicated the issue.
- [x] Explained how you fixed the issue or built the feature.

<!-- Thanks again for helping improve the project! 🙏 -->